### PR TITLE
Make use of mutable struct rather than Ref wrapper

### DIFF
--- a/src/Legendre.jl
+++ b/src/Legendre.jl
@@ -21,6 +21,7 @@ include("norm_sphere.jl")
 include("norm_table.jl")
 
 export legendre, legendre!
+include("scalar.jl")
 include("calculation.jl")
 
 # Other functionality

--- a/src/Legendre.jl
+++ b/src/Legendre.jl
@@ -9,6 +9,8 @@ module Legendre
 
 import Base: @boundscheck, @propagate_inbounds
 
+include("scalar.jl")
+
 # Public interfaces interface
 export AbstractLegendreNorm
 include("interface.jl")
@@ -21,7 +23,6 @@ include("norm_sphere.jl")
 include("norm_table.jl")
 
 export legendre, legendre!
-include("scalar.jl")
 include("calculation.jl")
 
 # Other functionality

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -20,6 +20,7 @@ Base.size(s::Scalar) = ()
 @propagate_inbounds Base.getindex(s::Scalar, ::CartesianIndex{0}) = s.x
 @propagate_inbounds Base.setindex!(s::Scalar, x) = (s.x = x; s)
 @propagate_inbounds Base.setindex!(s::Scalar, x, ::CartesianIndex{0}) = (s.x = x; s)
+Base.similar(s::Scalar{T}) where {T} = Scalar{T}()
 Base.similar(s::Scalar{T}, ::Tuple{}) where {T} = Scalar{T}()
 
 # Iteration on a scalar

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -1,0 +1,33 @@
+import Base.Broadcast: Broadcasted, AbstractArrayStyle, dotview, materialize
+
+"""
+    mutable struct Scalar{T} <: AbstractArray{T,0}
+
+A 0-dimensional (scalar) object, much like a `RefValue{T}`, but one which is an
+abstract array and assignable under broadcasting operations.
+"""
+mutable struct Scalar{T} <: AbstractArray{T,0}
+    x::T
+    Scalar{T}()  where {T} = new()
+    Scalar{T}(x) where {T} = new(x)
+end
+Scalar(s::T) where {T} = Scalar{T}(s)
+Base.isassigned(s::Scalar) = isdefined(s, :x)
+
+# AbstractArray interfaces
+Base.size(s::Scalar) = ()
+@propagate_inbounds Base.getindex(s::Scalar) = s.x
+@propagate_inbounds Base.getindex(s::Scalar, ::CartesianIndex{0}) = s.x
+@propagate_inbounds Base.setindex!(s::Scalar, x) = (s.x = x; s)
+@propagate_inbounds Base.setindex!(s::Scalar, x, ::CartesianIndex{0}) = (s.x = x; s)
+Base.similar(s::Scalar{T}, ::Tuple{}) where {T} = Scalar{T}()
+
+# Iteration on a scalar
+Base.iterate(s::Scalar) = (s.x, nothing)
+Base.iterate(s::Scalar, ::Nothing) = nothing
+
+# Broadcasting extensions
+@propagate_inbounds dotview(A::Scalar, ::CartesianIndex{0}) = A
+@propagate_inbounds dotview(A::Scalar, ::CartesianIndices{0,Tuple{}}) = A
+@propagate_inbounds Base.copyto!(dest::Scalar, bc::Broadcasted{<:AbstractArrayStyle{0}}) =
+    dest[] = materialize(bc)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Legendre
 const NumTypes = (Float32, Float64, BigFloat)
 
 const TESTLIST = [
+    "scalar" => "Broadcastable scalar",
     "legendre" => "Legendre",
    ]
 

--- a/test/scalar.jl
+++ b/test/scalar.jl
@@ -1,0 +1,39 @@
+module ScalarTest
+
+using Test
+using Legendre: Scalar
+
+@test Scalar{Float64}() isa Scalar{Float64}
+@test Scalar(1.0) isa Scalar{Float64}
+@test Scalar{Float64}(1) isa Scalar{Float64}
+@test isassigned(Scalar{Float64}())
+@test !isassigned(Scalar{BigFloat}())
+
+Z = CartesianIndex()
+I = CartesianIndices(())
+s = Scalar{Float64}()
+s[] = 1
+@test s[] == 1
+s[Z] = 2
+@test s[Z] == 2
+s[I] = fill(3)
+@test s[I] == fill(3)
+@test size(s) == ()
+@test ndims(s) == 0
+@test length(s) == 1
+@test similar(s) isa Scalar{Float64}
+@test similar(s, size(s)) isa Scalar{Float64}
+
+@test [x for x in s] == fill(s[])
+
+s .= fill(4)
+@test s[] == 4
+@test all(s .+ 1 .== 5)
+s[Z] .= fill(5)
+@test s[] == 5
+@test all(s[Z] .+ 1 .== 6)
+s[I] .= fill(6)
+@test s[I] == fill(6)
+@test all(s[I] .+ 1 .== 7)
+
+end # module ScalarTest


### PR DESCRIPTION
A past implementation made use of `Base.RefValue`s to allow assignment of scalar values from within a shared function, but as the base implementation has gotten more complicated (especially with respect to using broadcasted operations), the fact that `RefValue` is not a subtype of `AbstractArray` required a wrapper type to obtain the semantics we required.

Since that time, the scalar calculation performance has suffered due to extra allocations and indirections in code path. At this point, it is now more performant to simply use a `mutable struct` than an immutably-wrapped `RefValue`.

Before this change:
```julia
julia> @btime legendre(LegendreSphereNorm(), 3000, 2, cosd(0.25));
  96.858 μs (12 allocations: 192 bytes)
```

With this change:
```julia
julia> @btime legendre(LegendreSphereNorm(), 3000, 2, cosd(0.25));
  19.251 μs (6 allocations: 96 bytes)
```