### PR TITLE
Rearrange testing functions

### DIFF
--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -25,6 +25,11 @@ version = "0.2.0"
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
+[[DeepDiffs]]
+git-tree-sha1 = "9824894295b62a6a4ab6adf1c7bf337b3a9ca34c"
+uuid = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
+version = "1.2.0"
+
 [[DiffResults]]
 deps = ["StaticArrays"]
 git-tree-sha1 = "da24935df8e0c6cf28de340b958f6aac88eaa0cc"
@@ -71,6 +76,7 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.0"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
@@ -102,7 +108,7 @@ uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "1.0.2"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]
@@ -149,6 +155,12 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TestSetExtensions]]
+deps = ["DeepDiffs", "Distributed", "Test"]
+git-tree-sha1 = "3a2919a78b04c29a1a57b05e1618e473162b15d0"
+uuid = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
+version = "2.0.0"
 
 [[URIParser]]
 deps = ["Test", "Unicode"]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,6 +6,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestSetExtensions = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
 
 [compat]
 Documenter = "0.24.0"

--- a/test/analytic.jl
+++ b/test/analytic.jl
@@ -100,3 +100,16 @@ end
         @test all(isapprox.(nlm.*plm_norm, plm_sphr, atol=atol))
     end
 end
+
+################################
+# Other analytic checks / issues
+################################
+
+@testset "Numerical stability (issue CMB.jl#11)" begin
+    x = sind(-57.5)
+    lmax = 3 * 720
+    Λ = λlm.(0:lmax, 0:lmax, x)
+    # The amplitude bound of 1.5 is a very rough limit --- simply checking for
+    # unbounded growth.
+    @test all(abs.(Λ[end,:]) .< 1.5)
+end

--- a/test/analytic.jl
+++ b/test/analytic.jl
@@ -1,0 +1,102 @@
+using LinearAlgebra
+
+################################
+# ASSOCIATED LEGENDRE FUNCTIONS
+################################
+
+# P_0^0 is constant. Verify the output is invariant for several inputs.
+@testset "Constant P_0^0 ($T)" for T in NumTypes
+    @test @inferred(legendre(LegendreUnitNorm(), 0, 0, T(0.1))) isa T
+    @test all(legendre(LegendreUnitNorm(), 0, 0, z) == one(T)
+              for z in range(-one(T), one(T), length=10))
+end
+
+# Match P_ℓ^{m=0} terms for ℓ=1...9 where the analytical expressions
+# have been taken from a table of equations, assuming x = cos(π/4).
+@testset "Analytic checks for P_ℓ^0(cos(π/4)) ($T)" for T in NumTypes
+    LMAX = 9
+    plm = Matrix{T}(undef, LMAX+1, LMAX+1)
+    legendre!(LegendreUnitNorm(), plm, LMAX, LMAX, sqrt(T(2))/2)
+    @test plm[2, 1] ≈  sqrt(T(2))/2
+    @test plm[3, 1] ≈  T(1)/4
+    @test plm[4, 1] ≈ -sqrt(T(2))/8
+    @test plm[5, 1] ≈ -T(13)/32
+    @test plm[6, 1] ≈ -17sqrt(T(2))/64
+    @test plm[7, 1] ≈ -T(19)/128
+    @test plm[8, 1] ≈  23sqrt(T(2))/256
+    @test plm[9, 1] ≈  T(611)/2048
+    @test plm[10,1] ≈  827sqrt(T(2))/4096
+end
+
+##############################################################
+# SPHERICAL HARMONIC NORMALIZED ASSOCIATED LEGENDRE FUNCTIONS
+##############################################################
+
+# P_0^0 is constant. Verify the output is invariant for several inputs.
+@testset "Constant P_0^0 ($T)" for T in NumTypes
+    @test @inferred(legendre(LegendreSphereNorm(), 0, 0, T(0.1))) isa T
+    @test all(legendre(LegendreSphereNorm(), 0, 0, z) == sqrt(inv(4T(π)))
+              for z in range(-one(T), one(T), length=10))
+end
+
+# The initialization condition
+#
+#   P_ℓ^ℓ(x) = (-1)^ℓ (2ℓ-1)!! (1-x^2)^(ℓ/2)
+#
+# can be used with extended-precision computations for special values
+# of ℓ and m. To account for the spherical harmonic normalization,
+# the formula can be simplified to
+#
+#   λ_ℓ^ℓ(x) = (-1)^ℓ 1/sqrt(4π) sqrt((2ℓ+1)!!/(2ℓ)!!) (1-x^2)^(ℓ/2)
+#
+# We'll compute the coefficient separately since it's "easy", and then
+# we can use convenient angles that also expand to an exact analytic
+# value for (1-x^2)^(ℓ/2).
+#
+# Assuming x = cos(θ), the (1-x^2)^(ℓ/2) term simplifies to an
+# expression of \sin(θ):
+#
+#   (1-x^2)^(ℓ/2) = (sin^2 θ)^(ℓ/2) = (sin θ)^ℓ
+#
+# For θ = π/4:
+#
+#   * even ℓ => 1 / 2^(ℓ/2)
+#   * odd ℓ => 1 / (2^(k/2) sqrt(2)) where k=floor(ℓ/2).
+@testset "Analytic checks for λ_ℓ^m(cos(π/4))" begin
+    function SphericalPll_coeff(T, ℓ)
+        ratio(x) = sqrt(T(2x + 1) / T(2x))
+        factorials = mapreduce(ratio, *, 1:ℓ, init=one(T))
+        sign = (ℓ % 2 == 0) ? 1 : -1
+        return sign * sqrt(inv(4T(π))) * factorials
+    end
+
+    LMAX = 99
+    Λ = fill(0.0, LMAX+1, LMAX+1)
+    legendre!(LegendreSphereNorm(), Λ, LMAX, LMAX, cosd(45.0))
+
+    @test Λ[3,3]   ≈ SphericalPll_coeff(Float64,2)  / (2^1)
+    @test Λ[4,4]   ≈ SphericalPll_coeff(Float64,3)  / (2^1 * sqrt(2))
+    @test Λ[21,21] ≈ SphericalPll_coeff(Float64,20) / (2^10)
+    @test Λ[22,22] ≈ SphericalPll_coeff(Float64,21) / (2^10 * sqrt(2))
+    @test Λ[99,99] ≈ SphericalPll_coeff(Float64,98) / (2^49)
+    @test Λ[100,100] ≈ SphericalPll_coeff(Float64,99) / (2^49 * sqrt(2))
+end
+
+# The normal P_ℓ^m should be equal to the spherical harmonic normalized
+# λ_ℓ^m if we manually normalize them.
+@testset "Equality of N_ℓ^m × P_ℓ^m and λ_ℓ^m ($T)" for T in NumTypes
+    LMAX = 5
+    atol = max(eps(T(100)), eps(100.0)) # maximum(plm_norm) is of order 10²
+    plm_norm = zeros(T, LMAX+1, LMAX+1)
+    plm_sphr = zeros(T, LMAX+1, LMAX+1)
+
+    lmat = tril(repeat(collect(0:LMAX), 1, LMAX+1))
+    mmat = tril(repeat(collect(0:LMAX)', LMAX+1, 1))
+    nlm = tril(Nlm.(T, lmat, mmat))
+    for ii in 1:10
+        x = 2*T(rand()) - 1
+        legendre!(LegendreUnitNorm(), plm_norm, LMAX, LMAX, x)
+        legendre!(LegendreSphereNorm(), plm_sphr, LMAX, LMAX, x)
+        @test all(isapprox.(nlm.*plm_norm, plm_sphr, atol=atol))
+    end
+end

--- a/test/coeffs.jl
+++ b/test/coeffs.jl
@@ -1,0 +1,38 @@
+import ..TestSuite
+
+@testset "Precomputed coefficients" begin
+    TestSuite.runtests(LegendreUnitCoeff{Float64}(TestSuite.LMAX))
+    TestSuite.runtests(LegendreUnitCoeff{Float32}(TestSuite.LMAX))
+    TestSuite.runtests(LegendreUnitCoeff{BigFloat}(TestSuite.LMAX))
+
+    @testset "Coefficient table conversion" begin
+        dtab = LegendreSphereCoeff{Float64}(10)
+        ftab = convert(LegendreSphereCoeff{Float32}, dtab)
+
+        @test ftab isa LegendreSphereCoeff{Float32}
+        @test ftab.α == Float32.(dtab.α)
+        @test_throws MethodError convert(LegendreUnitCoeff{Float64}, dtab)
+    end
+
+    @testset "Setting mmax" begin
+        LMAX = 10
+        MMAX = 2
+        impltab = LegendreUnitCoeff{Float64}(LMAX)
+        fulltab = LegendreUnitCoeff{Float64}(LMAX, LMAX)
+        mmaxtab = LegendreUnitCoeff{Float64}(LMAX, MMAX)
+
+        # Equality of implicit and explicit [maximal] mmax
+        @test impltab.α == fulltab.α
+        @test impltab.α == fulltab.α
+        @test impltab.β == fulltab.β
+        @test impltab.μ == fulltab.μ
+        @test impltab.ν == fulltab.ν
+
+        # Equality of coefficients up to mmax for mmax limited
+        @test mmaxtab.α == @view fulltab.α[:, 1:(MMAX+1)]
+        @test mmaxtab.β == @view fulltab.β[:, 1:(MMAX+1)]
+        @test mmaxtab.μ == @view fulltab.μ[1:(MMAX+1)]
+        @test mmaxtab.ν == @view fulltab.ν[1:(MMAX+1)]
+    end
+end
+

--- a/test/doctests.jl
+++ b/test/doctests.jl
@@ -1,0 +1,11 @@
+using Documenter, Logging
+
+# Disable Documeter's Info logging
+oldlvl = Logging.min_enabled_level(current_logger())
+disable_logging(Logging.Info)
+try
+    DocMeta.setdocmeta!(Legendre, :DocTestSetup, :(using Legendre); recursive=true)
+    doctest(Legendre, testset="Doc Tests")
+finally
+    disable_logging(oldlvl - 1)
+end

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -1,0 +1,71 @@
+@testset "Degree/order domain errors" begin
+    LMAX = 10
+    MMAX = 2
+    Λ = Matrix{Float64}(undef, LMAX+1, MMAX+1)
+    norms = (LegendreUnitNorm(), LegendreSphereNorm(),
+             LegendreUnitCoeff{Float64}(LMAX, MMAX))
+
+    @testset "ℓ < 0 ($(typeof(N))" for N in norms
+        @test_throws DomainError legendre( N,    -1, 0, 0.5)
+        @test_throws DomainError legendre!(N, Λ, -1, 0, 0.5)
+    end
+    @testset "ℓ > 0 & m < 0 ($(typeof(N))" for N in norms
+        @test_throws DomainError legendre( N,    LMAX, -1, 0.5)
+        @test_throws DomainError legendre!(N, Λ, LMAX, -1, 0.5)
+    end
+    @testset "m > ℓ ($(typeof(N))" for N in norms
+        @test_throws DomainError legendre( N,    LMAX, LMAX+1, 0.5)
+        @test_throws DomainError legendre!(N, Λ, LMAX, LMAX+1, 0.5)
+    end
+end
+
+@testset "Degree/order range errors" begin
+    LMAX = 5
+    ctab = LegendreUnitCoeff{Float64}(LMAX)
+    # Throws on invalid l ranges
+    @test_throws ArgumentError Pl.(1:LMAX, 0.5)
+    @test_throws ArgumentError Plm.(1:LMAX, 0, 0.5)
+    @test_throws ArgumentError λlm.(1:LMAX, 0, 0.5)
+    @test_throws ArgumentError ctab.(1:LMAX, 0, 0.5)
+    @test_throws ArgumentError legendre.(ctab, 1:LMAX, 0, 0.5)
+    # Throws on invalid m ranges
+    @test_throws ArgumentError Plm.(0:LMAX, 1:LMAX, 0.5)
+    @test_throws ArgumentError λlm.(0:LMAX, 1:LMAX, 0.5)
+    @test_throws ArgumentError ctab.(0:LMAX, 1:LMAX, 0.5)
+    @test_throws ArgumentError legendre.(ctab, 0:LMAX, 1:LMAX, 0.5)
+end
+
+@testset "Output array bounds checking" begin
+    LMAX = 2
+
+    # Scalar argument
+    λ  = Vector{Float64}(undef, LMAX)
+    Λ₁ = Matrix{Float64}(undef, LMAX, LMAX+1)
+    Λ₂ = Matrix{Float64}(undef, LMAX+1, LMAX)
+    # Insufficient dim 1 (ℓ)
+    @test_throws DimensionMismatch Plm!(λ, LMAX, 0, 0.5)
+    @test_throws DimensionMismatch Plm!(Λ₁, LMAX, LMAX, 0.5)
+    # Insufficient dim 2 (m)
+    @test_throws DimensionMismatch Plm!(Λ₂, LMAX, LMAX, 0.5)
+
+    # Vector argument
+    Λ₃ = Array{Float64}(undef, 2, LMAX+1, LMAX+1)
+    Λ₄ = Array{Float64}(undef, 2, 2, LMAX+1, LMAX+1)
+    Λ₅ = Array{Float64}(undef, 2, 2, 2, LMAX+1, LMAX+1)
+    # Insufficient dimensions:
+    @test_throws DimensionMismatch Plm!(Λ₁, LMAX, LMAX, 0.0)
+    @test_throws DimensionMismatch Plm!(Λ₂, LMAX, LMAX, zeros(2))
+    @test_throws DimensionMismatch Plm!(Λ₃, LMAX, LMAX, zeros(2,2))
+    # Too many dimensions:
+    @test_throws DimensionMismatch Plm!(Λ₃, LMAX, LMAX, 0.0)
+    @test_throws DimensionMismatch Plm!(Λ₄, LMAX, LMAX, zeros(2))
+    @test_throws DimensionMismatch Plm!(Λ₅, LMAX, LMAX, zeros(2,2))
+end
+
+@testset "Precompute coefficient lmax/mmax" begin
+    LMAX, MMAX = 2, 0
+    ctab = LegendreUnitCoeff{Float64}(LMAX, MMAX)
+    @test_throws BoundsError ctab(LMAX+1, 0, 0.5)
+    @test_throws BoundsError ctab(LMAX, MMAX+1, 0.5)
+end
+

--- a/test/implementation.jl
+++ b/test/implementation.jl
@@ -1,4 +1,4 @@
-using LinearAlgebra, Random
+using Random
 
 @testset "Functor interface" begin
     LMAX = 10
@@ -115,13 +115,4 @@ end
     @test size(Plm.(LMAX, 0, z)) == sz
     @test size(Plm.(0:LMAX, 0, z)) == (sz..., LMAX+1)
     @test size(Plm.(0:LMAX, 0:LMAX, z)) == (sz..., LMAX+1, LMAX+1)
-end
-
-@testset "Numerical stability (issue #11)" begin
-    x = sind(-57.5)
-    lmax = 3 * 720
-    Λ = λlm.(0:lmax, 0:lmax, x)
-    # The amplitude bound of 1.5 is a very rough limit --- simply checking for
-    # unbounded growth.
-    @test all(abs.(Λ[end,:]) .< 1.5)
 end

--- a/test/legendre.jl
+++ b/test/legendre.jl
@@ -1,40 +1,5 @@
 using LinearAlgebra, Random
 
-import ..TestSuite
-TestSuite.runtests(LegendreUnitNorm())
-TestSuite.runtests(LegendreSphereNorm())
-TestSuite.runtests(LegendreUnitCoeff{Float64}(5))
-
-@testset "Coefficient table conversion" begin
-    dtab = LegendreSphereCoeff{Float64}(10)
-    ftab = convert(LegendreSphereCoeff{Float32}, dtab)
-
-    @test ftab isa LegendreSphereCoeff{Float32}
-    @test ftab.α == Float32.(dtab.α)
-    @test_throws MethodError convert(LegendreUnitCoeff{Float64}, dtab)
-end
-
-@testset "Setting mmax" begin
-    LMAX = 10
-    MMAX = 2
-    impltab = LegendreUnitCoeff{Float64}(LMAX)
-    fulltab = LegendreUnitCoeff{Float64}(LMAX, LMAX)
-    mmaxtab = LegendreUnitCoeff{Float64}(LMAX, MMAX)
-
-    # Equality of implicit and explicit [maximal] mmax
-    @test impltab.α == fulltab.α
-    @test impltab.α == fulltab.α
-    @test impltab.β == fulltab.β
-    @test impltab.μ == fulltab.μ
-    @test impltab.ν == fulltab.ν
-
-    # Equality of coefficients up to mmax for mmax limited
-    @test mmaxtab.α == @view fulltab.α[:, 1:(MMAX+1)]
-    @test mmaxtab.β == @view fulltab.β[:, 1:(MMAX+1)]
-    @test mmaxtab.μ == @view fulltab.μ[1:(MMAX+1)]
-    @test mmaxtab.ν == @view fulltab.ν[1:(MMAX+1)]
-end
-
 @testset "Functor interface" begin
     LMAX = 10
     leg = LegendreSphereCoeff{Float64}(LMAX)
@@ -46,31 +11,6 @@ end
     @test leg(1, 0.5) == legendre(leg, 1, 0.5)
     @test all(leg(λ₁, 2, 0.5) .== legendre!(leg, λ₂, LMAX, 2, 0.5))
     @test all(leg(Λ₁, 0.5) .== legendre!(leg, Λ₂, LMAX, LMAX, 0.5))
-end
-
-@testset "Mixed types" begin
-    LMAX = 10
-    legb! = LegendreUnitCoeff{BigFloat}(LMAX)
-    legd! = LegendreUnitCoeff{Float64}(LMAX)
-    λb = Vector{BigFloat}(undef, LMAX+1)
-    λd = Vector{Float64}(undef, LMAX+1)
-    xb = big"0.5"
-    xd = 5e-1
-
-    # Same table and array, mixed value
-    @test @inferred(legb!(λb, 2, xd)) isa typeof(λb)
-    @test @inferred(legd!(λd, 2, xb)) isa typeof(λd)
-
-    # Same table and value, mixed array
-    @test @inferred(legb!(λd, 2, xb)) isa typeof(λd)
-    @test @inferred(legd!(λb, 2, xd)) isa typeof(λb)
-
-    # Same array and value, mixed table
-    @test @inferred(legb!(λd, 2, xd)) isa typeof(λd)
-    @test @inferred(legd!(λb, 2, xb)) isa typeof(λb)
-
-    # All three mixed
-    @test @inferred(legb!(λd, 2, Float32(xd))) isa typeof(λd)
 end
 
 @testset "Equality of legendre[!]" begin

--- a/test/legendre.jl
+++ b/test/legendre.jl
@@ -1,386 +1,381 @@
-module LegendreTest
-    using Test
-    using LinearAlgebra, Random
-    using Legendre
-    import ..NumTypes
+using LinearAlgebra, Random
 
-    @testset "Coefficient table conversion" begin
-        dtab = LegendreSphereCoeff{Float64}(10)
-        ftab = convert(LegendreSphereCoeff{Float32}, dtab)
+@testset "Coefficient table conversion" begin
+    dtab = LegendreSphereCoeff{Float64}(10)
+    ftab = convert(LegendreSphereCoeff{Float32}, dtab)
 
-        @test ftab isa LegendreSphereCoeff{Float32}
-        @test ftab.α == Float32.(dtab.α)
-        @test_throws MethodError convert(LegendreUnitCoeff{Float64}, dtab)
+    @test ftab isa LegendreSphereCoeff{Float32}
+    @test ftab.α == Float32.(dtab.α)
+    @test_throws MethodError convert(LegendreUnitCoeff{Float64}, dtab)
+end
+
+@testset "Setting mmax" begin
+    LMAX = 10
+    MMAX = 2
+    impltab = LegendreUnitCoeff{Float64}(LMAX)
+    fulltab = LegendreUnitCoeff{Float64}(LMAX, LMAX)
+    mmaxtab = LegendreUnitCoeff{Float64}(LMAX, MMAX)
+
+    # Equality of implicit and explicit [maximal] mmax
+    @test impltab.α == fulltab.α
+    @test impltab.α == fulltab.α
+    @test impltab.β == fulltab.β
+    @test impltab.μ == fulltab.μ
+    @test impltab.ν == fulltab.ν
+
+    # Equality of coefficients up to mmax for mmax limited
+    @test mmaxtab.α == @view fulltab.α[:, 1:(MMAX+1)]
+    @test mmaxtab.β == @view fulltab.β[:, 1:(MMAX+1)]
+    @test mmaxtab.μ == @view fulltab.μ[1:(MMAX+1)]
+    @test mmaxtab.ν == @view fulltab.ν[1:(MMAX+1)]
+end
+
+@testset "Domain checking" begin
+    LMAX = 10
+    MMAX = 2
+    ctab = LegendreUnitCoeff{Float64}(LMAX)
+    mtab = LegendreUnitCoeff{Float64}(LMAX, MMAX)
+    λ = Vector{Float64}(undef, LMAX+1)
+    Λ = Matrix{Float64}(undef, LMAX+1, LMAX+1)
+
+    # Mathematical domain errors:
+    @test_throws DomainError Pl(-1, 0.5)
+    @test_throws DomainError Plm(-1, 0, 0.5)
+    @test_throws DomainError Plm(LMAX, -1, 0.5)
+    @test_throws DomainError Plm(LMAX, LMAX+1, 0.5)
+    @test_throws DomainError Pl!(λ, -1, 0.5)
+    @test_throws DomainError Plm!(Λ, -1, 0, 0.5)
+    @test_throws DomainError Plm!(Λ, LMAX, -1, 0.5)
+    @test_throws DomainError Plm!(Λ, LMAX, LMAX+1, 0.5)
+    @test_throws DomainError legendre(ctab, -1, 0, 0.5)
+    @test_throws DomainError legendre(ctab, LMAX, -1, 0.5)
+    @test_throws DomainError legendre(ctab, LMAX, LMAX+1, 0.5)
+    @test_throws DomainError legendre!(ctab, λ, -1, LMAX, 0.5)
+    @test_throws DomainError legendre!(ctab, Λ, -1, LMAX, 0.5)
+    @test_throws DomainError legendre!(ctab, Λ, LMAX, -1, 0.5)
+    @test_throws DomainError legendre!(ctab, Λ, LMAX, LMAX+1, 0.5)
+
+    # Bounds error for precomputed coefficient tables
+    @test_throws BoundsError legendre(ctab, LMAX+1, 0, 0.5)
+    @test_throws BoundsError legendre(mtab, LMAX, MMAX+1, 0.5)
+    @test_throws BoundsError legendre!(mtab, λ, LMAX, MMAX+1, 0.5)
+    @test_throws BoundsError legendre!(mtab, Λ, LMAX, MMAX+1, 0.5)
+end
+
+@testset "Output array bounds checking" begin
+    LMAX = 2
+    ctab = LegendreUnitCoeff{Float64}(LMAX)
+    λ  = Vector{Float64}(undef, LMAX)
+    Λ₁ = Matrix{Float64}(undef, LMAX, LMAX+1)
+    Λ₂ = Matrix{Float64}(undef, LMAX+1, LMAX)
+
+    # Bounds error for filling vector or matrix
+    @test_throws DimensionMismatch Pl!(λ, LMAX, 0.5)
+    @test_throws DimensionMismatch Plm!(λ, LMAX, 0, 0.5)
+    @test_throws DimensionMismatch Plm!(Λ₁, LMAX, LMAX, 0.5)
+    @test_throws DimensionMismatch Plm!(Λ₂, LMAX, LMAX, 0.5)
+    @test_throws DimensionMismatch legendre!(ctab, λ, LMAX, 0, 0.5)
+    @test_throws DimensionMismatch legendre!(ctab, Λ₁, LMAX, LMAX, 0.5)
+    @test_throws DimensionMismatch legendre!(ctab, Λ₂, LMAX, LMAX, 0.5)
+
+    # Compatibility of output storage
+    Λ₃ = Array{Float64}(undef, 2, LMAX+1, LMAX+1)
+    Λ₄ = Array{Float64}(undef, 2, 2, LMAX+1, LMAX+1)
+    Λ₅ = Array{Float64}(undef, 2, 2, 2, LMAX+1, LMAX+1)
+    # Insufficient dimensions:
+    @test_throws DimensionMismatch Plm!(Λ₁, LMAX, LMAX, 0.0)
+    @test_throws DimensionMismatch Plm!(Λ₂, LMAX, LMAX, zeros(2))
+    @test_throws DimensionMismatch Plm!(Λ₃, LMAX, LMAX, zeros(2,2))
+    # Too many dimensions:
+    @test_throws DimensionMismatch Plm!(Λ₃, LMAX, LMAX, 0.0)
+    @test_throws DimensionMismatch Plm!(Λ₄, LMAX, LMAX, zeros(2))
+    @test_throws DimensionMismatch Plm!(Λ₅, LMAX, LMAX, zeros(2,2))
+end
+
+@testset "Functor interface" begin
+    LMAX = 10
+    leg = LegendreSphereCoeff{Float64}(LMAX)
+    λ₁ = fill(0.0, LMAX+1)
+    λ₂ = fill(0.0, LMAX+1)
+    Λ₁ = fill(0.0, LMAX+1, LMAX+1)
+    Λ₂ = fill(0.0, LMAX+1, LMAX+1)
+    @test leg(1, 1, 0.5) == legendre(leg, 1, 1, 0.5)
+    @test leg(1, 0.5) == legendre(leg, 1, 0.5)
+    @test all(leg(λ₁, 2, 0.5) .== legendre!(leg, λ₂, LMAX, 2, 0.5))
+    @test all(leg(Λ₁, 0.5) .== legendre!(leg, Λ₂, LMAX, LMAX, 0.5))
+end
+
+@testset "Mixed types" begin
+    LMAX = 10
+    legb! = LegendreUnitCoeff{BigFloat}(LMAX)
+    legd! = LegendreUnitCoeff{Float64}(LMAX)
+    λb = Vector{BigFloat}(undef, LMAX+1)
+    λd = Vector{Float64}(undef, LMAX+1)
+    xb = big"0.5"
+    xd = 5e-1
+
+    # Same table and array, mixed value
+    @test @inferred(legb!(λb, 2, xd)) isa typeof(λb)
+    @test @inferred(legd!(λd, 2, xb)) isa typeof(λd)
+
+    # Same table and value, mixed array
+    @test @inferred(legb!(λd, 2, xb)) isa typeof(λd)
+    @test @inferred(legd!(λb, 2, xd)) isa typeof(λb)
+
+    # Same array and value, mixed table
+    @test @inferred(legb!(λd, 2, xd)) isa typeof(λd)
+    @test @inferred(legd!(λb, 2, xb)) isa typeof(λb)
+
+    # All three mixed
+    @test @inferred(legb!(λd, 2, Float32(xd))) isa typeof(λd)
+end
+
+@testset "Equality of legendre[!]" begin
+    LMAX = 10
+    x = 0.5
+    λ₂ = fill(0.0, LMAX+1)
+    Λ₂ = fill(0.0, LMAX+1, LMAX+1)
+
+    # P_l(x) is implemented with its own fast-path for m == 0
+    λ₁ = [Pl(l, x) for l in 0:LMAX]
+    @test λ₁ == Pl!(λ₂, LMAX, x)
+
+    # Use λlm instead of Plm to provide coverage for the convenience wrapper functions,
+    # too
+    leg! = LegendreSphereCoeff{Float64}(LMAX)
+    # Fill lower triangular matrix by hand
+    Λ₁ = [m > l ? 0.0 : λlm(l, m, x) for l in 0:LMAX, m in 0:LMAX]
+
+    # Test full matrix
+    @test Λ₁ == leg!(Λ₂, x)
+    @test Λ₁ == λlm!(Λ₂, LMAX, LMAX, x)
+
+    # Test single columns
+    fill!(λ₂, 0.0)
+    @test @view(Λ₁[:,2+1]) == leg!(λ₂, 2, x)
+    fill!(λ₂, 0.0)
+    @test @view(Λ₁[:,2+1]) == λlm!(λ₂, LMAX, 2, x)
+end
+
+#######################
+# LEGENDRE POLYNOMIALS
+#######################
+
+Random.seed!(2222)
+
+# P_0 is a constant. Verify the output is invariant.
+@testset "Constant P_0 ($T)" for T in NumTypes
+    @test @inferred(Pl(0, T(0.1))) isa T
+    pl = Pl.(0, 2 .* T.(rand(10)) .- 1)
+    @test all(pl[:,1] .== T(1.0))
+end
+
+################################
+# ASSOCIATED LEGENDRE FUNCTIONS
+################################
+
+# P_0^0 is constant. Verify the output is invariant for several inputs.
+@testset "Constant P_0^0 ($T)" for T in NumTypes
+    @test @inferred(Plm(0, 0, T(0.1))) isa T
+    plm = Plm.(0, 0, 2 .* T.(rand(10)) .- 1)
+    @test all(plm .== T(1.0))
+end
+
+# Match P_ℓ^{m=0} terms for ℓ=1...9 where the analytical expressions
+# have been taken from a table of equations, assuming x = cos(π/4).
+@testset "Analytic checks for P_ℓ^0(cos(π/4)) ($T)" for T in NumTypes
+    LMAX = 9
+    ctab = LegendreUnitCoeff{T}(LMAX)
+    plm = Matrix{T}(undef, LMAX+1, LMAX+1)
+    legendre!(ctab, plm, LMAX, LMAX, sqrt(T(2))/2)
+    @test plm[2, 1] ≈  sqrt(T(2))/2
+    @test plm[3, 1] ≈  T(1)/4
+    @test plm[4, 1] ≈ -sqrt(T(2))/8
+    @test plm[5, 1] ≈ -T(13)/32
+    @test plm[6, 1] ≈ -17sqrt(T(2))/64
+    @test plm[7, 1] ≈ -T(19)/128
+    @test plm[8, 1] ≈  23sqrt(T(2))/256
+    @test plm[9, 1] ≈  T(611)/2048
+    @test plm[10,1] ≈  827sqrt(T(2))/4096
+end
+
+# The associated Legendre functions P_ℓ^m should equate to the Legendre
+# polynomials P_ℓ for m=0, so check this is true.
+@testset "Equality of P_ℓ and P_ℓ^0 ($T)" for T in NumTypes
+    LMAX = 10
+    ctab = LegendreUnitCoeff{T}(LMAX)
+    pl  = Vector{T}(undef, LMAX+1)
+    plm = Matrix{T}(undef, LMAX+1, LMAX+1)
+    for ii in 1:10
+        x = 2T(rand()) - 1
+        Pl!(pl, LMAX, x)
+        legendre!(ctab, plm, LMAX, LMAX, x)
+        @test all(pl .≈ plm[:,1])
+    end
+end
+
+##############################################################
+# SPHERICAL HARMONIC NORMALIZED ASSOCIATED LEGENDRE FUNCTIONS
+##############################################################
+
+# The initialization condition
+#
+#   P_ℓ^ℓ(x) = (-1)^ℓ (2ℓ-1)!! (1-x^2)^(ℓ/2)
+#
+# can be used with extended-precision computations for special values
+# of ℓ and m. To account for the spherical harmonic normalization,
+# the formula can be simplified to
+#
+#   λ_ℓ^ℓ(x) = (-1)^ℓ 1/sqrt(4π) sqrt((2ℓ+1)!!/(2ℓ)!!) (1-x^2)^(ℓ/2)
+#
+# We'll compute the coefficient separately since it's "easy", and then
+# we can use convenient angles that also expand to an exact analytic
+# value for (1-x^2)^(ℓ/2).
+#
+# Assuming x = cos(θ), the (1-x^2)^(ℓ/2) term simplifies to an
+# expression of \sin(θ):
+#
+#   (1-x^2)^(ℓ/2) = (sin^2 θ)^(ℓ/2) = (sin θ)^ℓ
+#
+# For θ = π/4:
+#
+#   * even ℓ => 1 / 2^(ℓ/2)
+#   * odd ℓ => 1 / (2^(k/2) sqrt(2)) where k=floor(ℓ/2).
+@testset "Analytic checks for λ_ℓ^m(cos(π/4))" begin
+    function SphericalPll_coeff(T, ℓ)
+        factorials = mapreduce(x->sqrt((2x+1)/(2x)), *, 1:ℓ, init=1.0)
+        sign = (ℓ % 2 == 0) ? 1 : -1
+        return sign * sqrt(1/4π) * factorials
     end
 
-    @testset "Setting mmax" begin
-        LMAX = 10
-        MMAX = 2
-        impltab = LegendreUnitCoeff{Float64}(LMAX)
-        fulltab = LegendreUnitCoeff{Float64}(LMAX, LMAX)
-        mmaxtab = LegendreUnitCoeff{Float64}(LMAX, MMAX)
+    LMAX = 99
+    ctab = LegendreSphereCoeff{Float64}(LMAX)
+    Λ = Matrix{Float64}(undef, LMAX+1, LMAX+1)
+    Λ = legendre!(ctab, Λ, LMAX, LMAX, cosd(45.0))
 
-        # Equality of implicit and explicit [maximal] mmax
-        @test impltab.α == fulltab.α
-        @test impltab.α == fulltab.α
-        @test impltab.β == fulltab.β
-        @test impltab.μ == fulltab.μ
-        @test impltab.ν == fulltab.ν
+    @test Λ[3,3]   ≈ SphericalPll_coeff(Float64,2)  / (2^1)
+    @test Λ[4,4]   ≈ SphericalPll_coeff(Float64,3)  / (2^1 * sqrt(2))
+    @test Λ[21,21] ≈ SphericalPll_coeff(Float64,20) / (2^10)
+    @test Λ[22,22] ≈ SphericalPll_coeff(Float64,21) / (2^10 * sqrt(2))
+    @test Λ[99,99] ≈ SphericalPll_coeff(Float64,98) / (2^49)
+    @test Λ[100,100] ≈ SphericalPll_coeff(Float64,99) / (2^49 * sqrt(2))
+end
 
-        # Equality of coefficients up to mmax for mmax limited
-        @test mmaxtab.α == @view fulltab.α[:, 1:(MMAX+1)]
-        @test mmaxtab.β == @view fulltab.β[:, 1:(MMAX+1)]
-        @test mmaxtab.μ == @view fulltab.μ[1:(MMAX+1)]
-        @test mmaxtab.ν == @view fulltab.ν[1:(MMAX+1)]
+# The normal P_ℓ^m should be equal to the spherical harmonic normalized
+# λ_ℓ^m if we manually normalize them.
+@testset "Equality of N_ℓ^m*P_ℓ^m and λ_ℓ^m ($T)" for T in NumTypes
+    LMAX = 5
+    atol = max(eps(T(100)), eps(100.0)) # maximum(plm_norm) is of order 10²
+    ctab_norm = LegendreUnitCoeff{T}(LMAX)
+    ctab_sphr = LegendreSphereCoeff{T}(LMAX)
+    plm_norm = zeros(T, LMAX+1, LMAX+1)
+    plm_sphr = zeros(T, LMAX+1, LMAX+1)
+
+    lmat = tril(repeat(collect(0:LMAX), 1, LMAX+1))
+    mmat = tril(repeat(collect(0:LMAX)', LMAX+1, 1))
+    nlm = tril(Nlm.(T, lmat, mmat))
+    for ii in 1:10
+        x = 2*T(rand()) - 1
+        legendre!(ctab_norm, plm_norm, LMAX, LMAX, x)
+        legendre!(ctab_sphr, plm_sphr, LMAX, LMAX, x)
+        @test all(isapprox.(nlm.*plm_norm, plm_sphr, atol=atol))
     end
+end
 
-    @testset "Domain checking" begin
-        LMAX = 10
-        MMAX = 2
-        ctab = LegendreUnitCoeff{Float64}(LMAX)
-        mtab = LegendreUnitCoeff{Float64}(LMAX, MMAX)
-        λ = Vector{Float64}(undef, LMAX+1)
-        Λ = Matrix{Float64}(undef, LMAX+1, LMAX+1)
+# Test failed with world age problems when generated functions were incorrectly used;
+# numerical derivative via newer world's Dual numbers tests for this error.
+@testset "Derivatives via dual numbers" begin
+    using ForwardDiff: derivative
+    LMAX = 5
+    ctab = LegendreUnitCoeff{Float64}(LMAX)
 
-        # Mathematical domain errors:
-        @test_throws DomainError Pl(-1, 0.5)
-        @test_throws DomainError Plm(-1, 0, 0.5)
-        @test_throws DomainError Plm(LMAX, -1, 0.5)
-        @test_throws DomainError Plm(LMAX, LMAX+1, 0.5)
-        @test_throws DomainError Pl!(λ, -1, 0.5)
-        @test_throws DomainError Plm!(Λ, -1, 0, 0.5)
-        @test_throws DomainError Plm!(Λ, LMAX, -1, 0.5)
-        @test_throws DomainError Plm!(Λ, LMAX, LMAX+1, 0.5)
-        @test_throws DomainError legendre(ctab, -1, 0, 0.5)
-        @test_throws DomainError legendre(ctab, LMAX, -1, 0.5)
-        @test_throws DomainError legendre(ctab, LMAX, LMAX+1, 0.5)
-        @test_throws DomainError legendre!(ctab, λ, -1, LMAX, 0.5)
-        @test_throws DomainError legendre!(ctab, Λ, -1, LMAX, 0.5)
-        @test_throws DomainError legendre!(ctab, Λ, LMAX, -1, 0.5)
-        @test_throws DomainError legendre!(ctab, Λ, LMAX, LMAX+1, 0.5)
-
-        # Bounds error for precomputed coefficient tables
-        @test_throws BoundsError legendre(ctab, LMAX+1, 0, 0.5)
-        @test_throws BoundsError legendre(mtab, LMAX, MMAX+1, 0.5)
-        @test_throws BoundsError legendre!(mtab, λ, LMAX, MMAX+1, 0.5)
-        @test_throws BoundsError legendre!(mtab, Λ, LMAX, MMAX+1, 0.5)
+    # Numerical derivative for Plm via recurrence relations:
+    function num_deriv1(l, m, x)
+        d = -(l+1) * x * Plm(l, m, x) + (l - m + 1) * Plm(l+1, m, x)
+        return d / (x^2 - 1)
     end
+    dual_deriv1(l, m, x) = derivative(z -> Plm(l, m, z), x)
+    dual_deriv1_tab(l, m, x) = derivative(z -> ctab(l, m, z), x)
 
-    @testset "Output array bounds checking" begin
-        LMAX = 2
-        ctab = LegendreUnitCoeff{Float64}(LMAX)
-        λ  = Vector{Float64}(undef, LMAX)
-        Λ₁ = Matrix{Float64}(undef, LMAX, LMAX+1)
-        Λ₂ = Matrix{Float64}(undef, LMAX+1, LMAX)
-
-        # Bounds error for filling vector or matrix
-        @test_throws DimensionMismatch Pl!(λ, LMAX, 0.5)
-        @test_throws DimensionMismatch Plm!(λ, LMAX, 0, 0.5)
-        @test_throws DimensionMismatch Plm!(Λ₁, LMAX, LMAX, 0.5)
-        @test_throws DimensionMismatch Plm!(Λ₂, LMAX, LMAX, 0.5)
-        @test_throws DimensionMismatch legendre!(ctab, λ, LMAX, 0, 0.5)
-        @test_throws DimensionMismatch legendre!(ctab, Λ₁, LMAX, LMAX, 0.5)
-        @test_throws DimensionMismatch legendre!(ctab, Λ₂, LMAX, LMAX, 0.5)
-
-        # Compatibility of output storage
-        Λ₃ = Array{Float64}(undef, 2, LMAX+1, LMAX+1)
-        Λ₄ = Array{Float64}(undef, 2, 2, LMAX+1, LMAX+1)
-        Λ₅ = Array{Float64}(undef, 2, 2, 2, LMAX+1, LMAX+1)
-        # Insufficient dimensions:
-        @test_throws DimensionMismatch Plm!(Λ₁, LMAX, LMAX, 0.0)
-        @test_throws DimensionMismatch Plm!(Λ₂, LMAX, LMAX, zeros(2))
-        @test_throws DimensionMismatch Plm!(Λ₃, LMAX, LMAX, zeros(2,2))
-        # Too many dimensions:
-        @test_throws DimensionMismatch Plm!(Λ₃, LMAX, LMAX, 0.0)
-        @test_throws DimensionMismatch Plm!(Λ₄, LMAX, LMAX, zeros(2))
-        @test_throws DimensionMismatch Plm!(Λ₅, LMAX, LMAX, zeros(2,2))
+    for l in 0:LMAX, m in 0:l
+        x = 2rand() - 1
+        @test num_deriv1(l, m, x) ≈ dual_deriv1(l, m, x)
+        @test num_deriv1(l, m, x) ≈ dual_deriv1_tab(l, m, x)
     end
+end
 
-    @testset "Functor interface" begin
-        LMAX = 10
-        leg = LegendreSphereCoeff{Float64}(LMAX)
-        λ₁ = fill(0.0, LMAX+1)
-        λ₂ = fill(0.0, LMAX+1)
-        Λ₁ = fill(0.0, LMAX+1, LMAX+1)
-        Λ₂ = fill(0.0, LMAX+1, LMAX+1)
-        @test leg(1, 1, 0.5) == legendre(leg, 1, 1, 0.5)
-        @test leg(1, 0.5) == legendre(leg, 1, 0.5)
-        @test all(leg(λ₁, 2, 0.5) .== legendre!(leg, λ₂, LMAX, 2, 0.5))
-        @test all(leg(Λ₁, 0.5) .== legendre!(leg, Λ₂, LMAX, LMAX, 0.5))
-    end
+@testset "Broadcasting arguments" begin
+    LMAX = 5
+    ctab = LegendreSphereCoeff{Float64}(LMAX)
+    x = 0.5
 
-    @testset "Mixed types" begin
-        LMAX = 10
-        legb! = LegendreUnitCoeff{BigFloat}(LMAX)
-        legd! = LegendreUnitCoeff{Float64}(LMAX)
-        λb = Vector{BigFloat}(undef, LMAX+1)
-        λd = Vector{Float64}(undef, LMAX+1)
-        xb = big"0.5"
-        xd = 5e-1
+    # Single (l,m) for single z
+    @test Pl.(LMAX, x)        == Pl(LMAX, x)
+    @test Plm.(LMAX, LMAX, x) == Plm(LMAX, LMAX, x)
+    @test λlm.(LMAX, LMAX, x)  == λlm(LMAX, LMAX, x)
+    @test ctab.(LMAX, x)       == λlm(LMAX, 0, x)
+    @test ctab.(LMAX, LMAX, x) == λlm(LMAX, LMAX, x)
+    @test legendre.(LegendreSphereNorm(), LMAX, x)       == λlm(LMAX, 0, x)
+    @test legendre.(LegendreSphereNorm(), LMAX, LMAX, x) == λlm(LMAX, LMAX, x)
 
-        # Same table and array, mixed value
-        @test @inferred(legb!(λb, 2, xd)) isa typeof(λb)
-        @test @inferred(legd!(λd, 2, xb)) isa typeof(λd)
+    z = range(-1, 1, length=10)
+    Λ = zeros(length(z), LMAX + 1, LMAX + 1)
 
-        # Same table and value, mixed array
-        @test @inferred(legb!(λd, 2, xb)) isa typeof(λd)
-        @test @inferred(legd!(λb, 2, xd)) isa typeof(λb)
+    # Single (l,m) over multiple z
+    legendre!(LegendreUnitNorm(), Λ, LMAX, LMAX, z)
+    @test Pl.(LMAX, z)        == Λ[:,LMAX+1,1]
+    @test Plm.(LMAX, LMAX, z) == Λ[:,LMAX+1,LMAX+1]
+    legendre!(LegendreSphereNorm(), Λ, LMAX, LMAX, z)
+    @test λlm.(LMAX, LMAX, z)  == Λ[:,LMAX+1,LMAX+1]
+    @test ctab.(LMAX, z)       == Λ[:,LMAX+1,1]
+    @test ctab.(LMAX, LMAX, z) == Λ[:,LMAX+1,LMAX+1]
+    @test legendre.(LegendreSphereNorm(), LMAX, z)       == Λ[:,LMAX+1,1]
+    @test legendre.(LegendreSphereNorm(), LMAX, LMAX, z) == Λ[:,LMAX+1,LMAX+1]
 
-        # Same array and value, mixed table
-        @test @inferred(legb!(λd, 2, xd)) isa typeof(λd)
-        @test @inferred(legd!(λb, 2, xb)) isa typeof(λb)
+    # All l for fixed m over multiple z
+    legendre!(LegendreUnitNorm(), Λ, LMAX, LMAX, z)
+    @test Pl.(0:LMAX, z)        == Λ[:,:,1]
+    @test Plm.(0:LMAX, LMAX, z) == Λ[:,:,LMAX+1]
+    legendre!(LegendreSphereNorm(), Λ, LMAX, LMAX, z)
+    @test λlm.(0:LMAX, LMAX, z)  == Λ[:,:,LMAX+1]
+    @test ctab.(0:LMAX, z)       == Λ[:,:,1]
+    @test ctab.(0:LMAX, LMAX, z) == Λ[:,:,LMAX+1]
+    @test legendre.(LegendreSphereNorm(), 0:LMAX, z)       == Λ[:,:,1]
+    @test legendre.(LegendreSphereNorm(), 0:LMAX, LMAX, z) == Λ[:,:,LMAX+1]
 
-        # All three mixed
-        @test @inferred(legb!(λd, 2, Float32(xd))) isa typeof(λd)
-    end
+    # All l and m over multiple z
+    legendre!(LegendreUnitNorm(), Λ, LMAX, LMAX, z)
+    @test Plm.(0:LMAX, 0:LMAX, z) == Λ
+    legendre!(LegendreSphereNorm(), Λ, LMAX, LMAX, z)
+    @test λlm.(0:LMAX, 0:LMAX, z)  == Λ
+    @test ctab.(0:LMAX, 0:LMAX, z) == Λ
+    @test legendre.(LegendreSphereNorm(), 0:LMAX, 0:LMAX, z) == Λ
 
-    @testset "Equality of legendre[!]" begin
-        LMAX = 10
-        x = 0.5
-        λ₂ = fill(0.0, LMAX+1)
-        Λ₂ = fill(0.0, LMAX+1, LMAX+1)
+    # Shape-preservation of multi-dimensional arguments
+    sz = (5, 10)
+    z = collect(reshape(range(-1.0, 1.0, length=prod(sz)), sz))
+    @test size(Plm.(LMAX, 0, z)) == sz
+    @test size(Plm.(0:LMAX, 0, z)) == (sz..., LMAX+1)
+    @test size(Plm.(0:LMAX, 0:LMAX, z)) == (sz..., LMAX+1, LMAX+1)
 
-        # P_l(x) is implemented with its own fast-path for m == 0
-        λ₁ = [Pl(l, x) for l in 0:LMAX]
-        @test λ₁ == Pl!(λ₂, LMAX, x)
+    # Throws on invalid l ranges
+    @test_throws ArgumentError Pl.(1:LMAX, z)
+    @test_throws ArgumentError Plm.(1:LMAX, 0, z)
+    @test_throws ArgumentError λlm.(1:LMAX, 0, z)
+    @test_throws ArgumentError ctab.(1:LMAX, 0, z)
+    @test_throws ArgumentError legendre.(ctab, 1:LMAX, 0, z)
+    # Throws on invalid m ranges
+    @test_throws ArgumentError Plm.(0:LMAX, 1:LMAX, z)
+    @test_throws ArgumentError λlm.(0:LMAX, 1:LMAX, z)
+    @test_throws ArgumentError ctab.(0:LMAX, 1:LMAX, z)
+    @test_throws ArgumentError legendre.(ctab, 0:LMAX, 1:LMAX, z)
+end
 
-        # Use λlm instead of Plm to provide coverage for the convenience wrapper functions,
-        # too
-        leg! = LegendreSphereCoeff{Float64}(LMAX)
-        # Fill lower triangular matrix by hand
-        Λ₁ = [m > l ? 0.0 : λlm(l, m, x) for l in 0:LMAX, m in 0:LMAX]
-
-        # Test full matrix
-        @test Λ₁ == leg!(Λ₂, x)
-        @test Λ₁ == λlm!(Λ₂, LMAX, LMAX, x)
-
-        # Test single columns
-        fill!(λ₂, 0.0)
-        @test @view(Λ₁[:,2+1]) == leg!(λ₂, 2, x)
-        fill!(λ₂, 0.0)
-        @test @view(Λ₁[:,2+1]) == λlm!(λ₂, LMAX, 2, x)
-    end
-
-    #######################
-    # LEGENDRE POLYNOMIALS
-    #######################
-
-    Random.seed!(2222)
-
-    # P_0 is a constant. Verify the output is invariant.
-    @testset "Constant P_0 ($T)" for T in NumTypes
-        @test @inferred(Pl(0, T(0.1))) isa T
-        pl = Pl.(0, 2 .* T.(rand(10)) .- 1)
-        @test all(pl[:,1] .== T(1.0))
-    end
-
-    ################################
-    # ASSOCIATED LEGENDRE FUNCTIONS
-    ################################
-
-    # P_0^0 is constant. Verify the output is invariant for several inputs.
-    @testset "Constant P_0^0 ($T)" for T in NumTypes
-        @test @inferred(Plm(0, 0, T(0.1))) isa T
-        plm = Plm.(0, 0, 2 .* T.(rand(10)) .- 1)
-        @test all(plm .== T(1.0))
-    end
-
-    # Match P_ℓ^{m=0} terms for ℓ=1...9 where the analytical expressions
-    # have been taken from a table of equations, assuming x = cos(π/4).
-    @testset "Analytic checks for P_ℓ^0(cos(π/4)) ($T)" for T in NumTypes
-        LMAX = 9
-        ctab = LegendreUnitCoeff{T}(LMAX)
-        plm = Matrix{T}(undef, LMAX+1, LMAX+1)
-        legendre!(ctab, plm, LMAX, LMAX, sqrt(T(2))/2)
-        @test plm[2, 1] ≈  sqrt(T(2))/2
-        @test plm[3, 1] ≈  T(1)/4
-        @test plm[4, 1] ≈ -sqrt(T(2))/8
-        @test plm[5, 1] ≈ -T(13)/32
-        @test plm[6, 1] ≈ -17sqrt(T(2))/64
-        @test plm[7, 1] ≈ -T(19)/128
-        @test plm[8, 1] ≈  23sqrt(T(2))/256
-        @test plm[9, 1] ≈  T(611)/2048
-        @test plm[10,1] ≈  827sqrt(T(2))/4096
-    end
-
-    # The associated Legendre functions P_ℓ^m should equate to the Legendre
-    # polynomials P_ℓ for m=0, so check this is true.
-    @testset "Equality of P_ℓ and P_ℓ^0 ($T)" for T in NumTypes
-        LMAX = 10
-        ctab = LegendreUnitCoeff{T}(LMAX)
-        pl  = Vector{T}(undef, LMAX+1)
-        plm = Matrix{T}(undef, LMAX+1, LMAX+1)
-        for ii in 1:10
-            x = 2T(rand()) - 1
-            Pl!(pl, LMAX, x)
-            legendre!(ctab, plm, LMAX, LMAX, x)
-            @test all(pl .≈ plm[:,1])
-        end
-    end
-
-    ##############################################################
-    # SPHERICAL HARMONIC NORMALIZED ASSOCIATED LEGENDRE FUNCTIONS
-    ##############################################################
-
-    # The initialization condition
-    #
-    #   P_ℓ^ℓ(x) = (-1)^ℓ (2ℓ-1)!! (1-x^2)^(ℓ/2)
-    #
-    # can be used with extended-precision computations for special values
-    # of ℓ and m. To account for the spherical harmonic normalization,
-    # the formula can be simplified to
-    #
-    #   λ_ℓ^ℓ(x) = (-1)^ℓ 1/sqrt(4π) sqrt((2ℓ+1)!!/(2ℓ)!!) (1-x^2)^(ℓ/2)
-    #
-    # We'll compute the coefficient separately since it's "easy", and then
-    # we can use convenient angles that also expand to an exact analytic
-    # value for (1-x^2)^(ℓ/2).
-    #
-    # Assuming x = cos(θ), the (1-x^2)^(ℓ/2) term simplifies to an
-    # expression of \sin(θ):
-    #
-    #   (1-x^2)^(ℓ/2) = (sin^2 θ)^(ℓ/2) = (sin θ)^ℓ
-    #
-    # For θ = π/4:
-    #
-    #   * even ℓ => 1 / 2^(ℓ/2)
-    #   * odd ℓ => 1 / (2^(k/2) sqrt(2)) where k=floor(ℓ/2).
-    @testset "Analytic checks for λ_ℓ^m(cos(π/4))" begin
-        function SphericalPll_coeff(T, ℓ)
-            factorials = mapreduce(x->sqrt((2x+1)/(2x)), *, 1:ℓ, init=1.0)
-            sign = (ℓ % 2 == 0) ? 1 : -1
-            return sign * sqrt(1/4π) * factorials
-        end
-
-        LMAX = 99
-        ctab = LegendreSphereCoeff{Float64}(LMAX)
-        Λ = Matrix{Float64}(undef, LMAX+1, LMAX+1)
-        Λ = legendre!(ctab, Λ, LMAX, LMAX, cosd(45.0))
-
-        @test Λ[3,3]   ≈ SphericalPll_coeff(Float64,2)  / (2^1)
-        @test Λ[4,4]   ≈ SphericalPll_coeff(Float64,3)  / (2^1 * sqrt(2))
-        @test Λ[21,21] ≈ SphericalPll_coeff(Float64,20) / (2^10)
-        @test Λ[22,22] ≈ SphericalPll_coeff(Float64,21) / (2^10 * sqrt(2))
-        @test Λ[99,99] ≈ SphericalPll_coeff(Float64,98) / (2^49)
-        @test Λ[100,100] ≈ SphericalPll_coeff(Float64,99) / (2^49 * sqrt(2))
-    end
-
-    # The normal P_ℓ^m should be equal to the spherical harmonic normalized
-    # λ_ℓ^m if we manually normalize them.
-    @testset "Equality of N_ℓ^m*P_ℓ^m and λ_ℓ^m ($T)" for T in NumTypes
-        LMAX = 5
-        atol = max(eps(T(100)), eps(100.0)) # maximum(plm_norm) is of order 10²
-        ctab_norm = LegendreUnitCoeff{T}(LMAX)
-        ctab_sphr = LegendreSphereCoeff{T}(LMAX)
-        plm_norm = zeros(T, LMAX+1, LMAX+1)
-        plm_sphr = zeros(T, LMAX+1, LMAX+1)
-
-        lmat = tril(repeat(collect(0:LMAX), 1, LMAX+1))
-        mmat = tril(repeat(collect(0:LMAX)', LMAX+1, 1))
-        nlm = tril(Nlm.(T, lmat, mmat))
-        for ii in 1:10
-            x = 2*T(rand()) - 1
-            legendre!(ctab_norm, plm_norm, LMAX, LMAX, x)
-            legendre!(ctab_sphr, plm_sphr, LMAX, LMAX, x)
-            @test all(isapprox.(nlm.*plm_norm, plm_sphr, atol=atol))
-        end
-    end
-
-    # Test failed with world age problems when generated functions were incorrectly used;
-    # numerical derivative via newer world's Dual numbers tests for this error.
-    @testset "Derivatives via dual numbers" begin
-        using ForwardDiff: derivative
-        LMAX = 5
-        ctab = LegendreUnitCoeff{Float64}(LMAX)
-
-        # Numerical derivative for Plm via recurrence relations:
-        function num_deriv1(l, m, x)
-            d = -(l+1) * x * Plm(l, m, x) + (l - m + 1) * Plm(l+1, m, x)
-            return d / (x^2 - 1)
-        end
-        dual_deriv1(l, m, x) = derivative(z -> Plm(l, m, z), x)
-        dual_deriv1_tab(l, m, x) = derivative(z -> ctab(l, m, z), x)
-
-        for l in 0:LMAX, m in 0:l
-            x = 2rand() - 1
-            @test num_deriv1(l, m, x) ≈ dual_deriv1(l, m, x)
-            @test num_deriv1(l, m, x) ≈ dual_deriv1_tab(l, m, x)
-        end
-    end
-
-    @testset "Broadcasting arguments" begin
-        LMAX = 5
-        ctab = LegendreSphereCoeff{Float64}(LMAX)
-        x = 0.5
-
-        # Single (l,m) for single z
-        @test Pl.(LMAX, x)        == Pl(LMAX, x)
-        @test Plm.(LMAX, LMAX, x) == Plm(LMAX, LMAX, x)
-        @test λlm.(LMAX, LMAX, x)  == λlm(LMAX, LMAX, x)
-        @test ctab.(LMAX, x)       == λlm(LMAX, 0, x)
-        @test ctab.(LMAX, LMAX, x) == λlm(LMAX, LMAX, x)
-        @test legendre.(LegendreSphereNorm(), LMAX, x)       == λlm(LMAX, 0, x)
-        @test legendre.(LegendreSphereNorm(), LMAX, LMAX, x) == λlm(LMAX, LMAX, x)
-
-        z = range(-1, 1, length=10)
-        Λ = zeros(length(z), LMAX + 1, LMAX + 1)
-
-        # Single (l,m) over multiple z
-        legendre!(LegendreUnitNorm(), Λ, LMAX, LMAX, z)
-        @test Pl.(LMAX, z)        == Λ[:,LMAX+1,1]
-        @test Plm.(LMAX, LMAX, z) == Λ[:,LMAX+1,LMAX+1]
-        legendre!(LegendreSphereNorm(), Λ, LMAX, LMAX, z)
-        @test λlm.(LMAX, LMAX, z)  == Λ[:,LMAX+1,LMAX+1]
-        @test ctab.(LMAX, z)       == Λ[:,LMAX+1,1]
-        @test ctab.(LMAX, LMAX, z) == Λ[:,LMAX+1,LMAX+1]
-        @test legendre.(LegendreSphereNorm(), LMAX, z)       == Λ[:,LMAX+1,1]
-        @test legendre.(LegendreSphereNorm(), LMAX, LMAX, z) == Λ[:,LMAX+1,LMAX+1]
-
-        # All l for fixed m over multiple z
-        legendre!(LegendreUnitNorm(), Λ, LMAX, LMAX, z)
-        @test Pl.(0:LMAX, z)        == Λ[:,:,1]
-        @test Plm.(0:LMAX, LMAX, z) == Λ[:,:,LMAX+1]
-        legendre!(LegendreSphereNorm(), Λ, LMAX, LMAX, z)
-        @test λlm.(0:LMAX, LMAX, z)  == Λ[:,:,LMAX+1]
-        @test ctab.(0:LMAX, z)       == Λ[:,:,1]
-        @test ctab.(0:LMAX, LMAX, z) == Λ[:,:,LMAX+1]
-        @test legendre.(LegendreSphereNorm(), 0:LMAX, z)       == Λ[:,:,1]
-        @test legendre.(LegendreSphereNorm(), 0:LMAX, LMAX, z) == Λ[:,:,LMAX+1]
-
-        # All l and m over multiple z
-        legendre!(LegendreUnitNorm(), Λ, LMAX, LMAX, z)
-        @test Plm.(0:LMAX, 0:LMAX, z) == Λ
-        legendre!(LegendreSphereNorm(), Λ, LMAX, LMAX, z)
-        @test λlm.(0:LMAX, 0:LMAX, z)  == Λ
-        @test ctab.(0:LMAX, 0:LMAX, z) == Λ
-        @test legendre.(LegendreSphereNorm(), 0:LMAX, 0:LMAX, z) == Λ
-
-        # Shape-preservation of multi-dimensional arguments
-        sz = (5, 10)
-        z = collect(reshape(range(-1.0, 1.0, length=prod(sz)), sz))
-        @test size(Plm.(LMAX, 0, z)) == sz
-        @test size(Plm.(0:LMAX, 0, z)) == (sz..., LMAX+1)
-        @test size(Plm.(0:LMAX, 0:LMAX, z)) == (sz..., LMAX+1, LMAX+1)
-
-        # Throws on invalid l ranges
-        @test_throws ArgumentError Pl.(1:LMAX, z)
-        @test_throws ArgumentError Plm.(1:LMAX, 0, z)
-        @test_throws ArgumentError λlm.(1:LMAX, 0, z)
-        @test_throws ArgumentError ctab.(1:LMAX, 0, z)
-        @test_throws ArgumentError legendre.(ctab, 1:LMAX, 0, z)
-        # Throws on invalid m ranges
-        @test_throws ArgumentError Plm.(0:LMAX, 1:LMAX, z)
-        @test_throws ArgumentError λlm.(0:LMAX, 1:LMAX, z)
-        @test_throws ArgumentError ctab.(0:LMAX, 1:LMAX, z)
-        @test_throws ArgumentError legendre.(ctab, 0:LMAX, 1:LMAX, z)
-    end
-
-    @testset "Numerical stability (issue #11)" begin
-        x = sind(-57.5)
-        lmax = 3 * 720
-        Λ = λlm.(0:lmax, 0:lmax, x)
-        # The amplitude bound of 1.5 is a very rough limit --- simply checking for
-        # unbounded growth.
-        @test all(abs.(Λ[end,:]) .< 1.5)
-    end
+@testset "Numerical stability (issue #11)" begin
+    x = sind(-57.5)
+    lmax = 3 * 720
+    Λ = λlm.(0:lmax, 0:lmax, x)
+    # The amplitude bound of 1.5 is a very rough limit --- simply checking for
+    # unbounded growth.
+    @test all(abs.(Λ[end,:]) .< 1.5)
 end

--- a/test/legendre.jl
+++ b/test/legendre.jl
@@ -1,5 +1,10 @@
 using LinearAlgebra, Random
 
+import ..TestSuite
+TestSuite.runtests(LegendreUnitNorm())
+TestSuite.runtests(LegendreSphereNorm())
+TestSuite.runtests(LegendreUnitCoeff{Float64}(5))
+
 @testset "Coefficient table conversion" begin
     dtab = LegendreSphereCoeff{Float64}(10)
     ftab = convert(LegendreSphereCoeff{Float32}, dtab)
@@ -155,131 +160,6 @@ end
     @test @view(Λ₁[:,2+1]) == leg!(λ₂, 2, x)
     fill!(λ₂, 0.0)
     @test @view(Λ₁[:,2+1]) == λlm!(λ₂, LMAX, 2, x)
-end
-
-#######################
-# LEGENDRE POLYNOMIALS
-#######################
-
-Random.seed!(2222)
-
-# P_0 is a constant. Verify the output is invariant.
-@testset "Constant P_0 ($T)" for T in NumTypes
-    @test @inferred(Pl(0, T(0.1))) isa T
-    pl = Pl.(0, 2 .* T.(rand(10)) .- 1)
-    @test all(pl[:,1] .== T(1.0))
-end
-
-################################
-# ASSOCIATED LEGENDRE FUNCTIONS
-################################
-
-# P_0^0 is constant. Verify the output is invariant for several inputs.
-@testset "Constant P_0^0 ($T)" for T in NumTypes
-    @test @inferred(Plm(0, 0, T(0.1))) isa T
-    plm = Plm.(0, 0, 2 .* T.(rand(10)) .- 1)
-    @test all(plm .== T(1.0))
-end
-
-# Match P_ℓ^{m=0} terms for ℓ=1...9 where the analytical expressions
-# have been taken from a table of equations, assuming x = cos(π/4).
-@testset "Analytic checks for P_ℓ^0(cos(π/4)) ($T)" for T in NumTypes
-    LMAX = 9
-    ctab = LegendreUnitCoeff{T}(LMAX)
-    plm = Matrix{T}(undef, LMAX+1, LMAX+1)
-    legendre!(ctab, plm, LMAX, LMAX, sqrt(T(2))/2)
-    @test plm[2, 1] ≈  sqrt(T(2))/2
-    @test plm[3, 1] ≈  T(1)/4
-    @test plm[4, 1] ≈ -sqrt(T(2))/8
-    @test plm[5, 1] ≈ -T(13)/32
-    @test plm[6, 1] ≈ -17sqrt(T(2))/64
-    @test plm[7, 1] ≈ -T(19)/128
-    @test plm[8, 1] ≈  23sqrt(T(2))/256
-    @test plm[9, 1] ≈  T(611)/2048
-    @test plm[10,1] ≈  827sqrt(T(2))/4096
-end
-
-# The associated Legendre functions P_ℓ^m should equate to the Legendre
-# polynomials P_ℓ for m=0, so check this is true.
-@testset "Equality of P_ℓ and P_ℓ^0 ($T)" for T in NumTypes
-    LMAX = 10
-    ctab = LegendreUnitCoeff{T}(LMAX)
-    pl  = Vector{T}(undef, LMAX+1)
-    plm = Matrix{T}(undef, LMAX+1, LMAX+1)
-    for ii in 1:10
-        x = 2T(rand()) - 1
-        Pl!(pl, LMAX, x)
-        legendre!(ctab, plm, LMAX, LMAX, x)
-        @test all(pl .≈ plm[:,1])
-    end
-end
-
-##############################################################
-# SPHERICAL HARMONIC NORMALIZED ASSOCIATED LEGENDRE FUNCTIONS
-##############################################################
-
-# The initialization condition
-#
-#   P_ℓ^ℓ(x) = (-1)^ℓ (2ℓ-1)!! (1-x^2)^(ℓ/2)
-#
-# can be used with extended-precision computations for special values
-# of ℓ and m. To account for the spherical harmonic normalization,
-# the formula can be simplified to
-#
-#   λ_ℓ^ℓ(x) = (-1)^ℓ 1/sqrt(4π) sqrt((2ℓ+1)!!/(2ℓ)!!) (1-x^2)^(ℓ/2)
-#
-# We'll compute the coefficient separately since it's "easy", and then
-# we can use convenient angles that also expand to an exact analytic
-# value for (1-x^2)^(ℓ/2).
-#
-# Assuming x = cos(θ), the (1-x^2)^(ℓ/2) term simplifies to an
-# expression of \sin(θ):
-#
-#   (1-x^2)^(ℓ/2) = (sin^2 θ)^(ℓ/2) = (sin θ)^ℓ
-#
-# For θ = π/4:
-#
-#   * even ℓ => 1 / 2^(ℓ/2)
-#   * odd ℓ => 1 / (2^(k/2) sqrt(2)) where k=floor(ℓ/2).
-@testset "Analytic checks for λ_ℓ^m(cos(π/4))" begin
-    function SphericalPll_coeff(T, ℓ)
-        factorials = mapreduce(x->sqrt((2x+1)/(2x)), *, 1:ℓ, init=1.0)
-        sign = (ℓ % 2 == 0) ? 1 : -1
-        return sign * sqrt(1/4π) * factorials
-    end
-
-    LMAX = 99
-    ctab = LegendreSphereCoeff{Float64}(LMAX)
-    Λ = Matrix{Float64}(undef, LMAX+1, LMAX+1)
-    Λ = legendre!(ctab, Λ, LMAX, LMAX, cosd(45.0))
-
-    @test Λ[3,3]   ≈ SphericalPll_coeff(Float64,2)  / (2^1)
-    @test Λ[4,4]   ≈ SphericalPll_coeff(Float64,3)  / (2^1 * sqrt(2))
-    @test Λ[21,21] ≈ SphericalPll_coeff(Float64,20) / (2^10)
-    @test Λ[22,22] ≈ SphericalPll_coeff(Float64,21) / (2^10 * sqrt(2))
-    @test Λ[99,99] ≈ SphericalPll_coeff(Float64,98) / (2^49)
-    @test Λ[100,100] ≈ SphericalPll_coeff(Float64,99) / (2^49 * sqrt(2))
-end
-
-# The normal P_ℓ^m should be equal to the spherical harmonic normalized
-# λ_ℓ^m if we manually normalize them.
-@testset "Equality of N_ℓ^m*P_ℓ^m and λ_ℓ^m ($T)" for T in NumTypes
-    LMAX = 5
-    atol = max(eps(T(100)), eps(100.0)) # maximum(plm_norm) is of order 10²
-    ctab_norm = LegendreUnitCoeff{T}(LMAX)
-    ctab_sphr = LegendreSphereCoeff{T}(LMAX)
-    plm_norm = zeros(T, LMAX+1, LMAX+1)
-    plm_sphr = zeros(T, LMAX+1, LMAX+1)
-
-    lmat = tril(repeat(collect(0:LMAX), 1, LMAX+1))
-    mmat = tril(repeat(collect(0:LMAX)', LMAX+1, 1))
-    nlm = tril(Nlm.(T, lmat, mmat))
-    for ii in 1:10
-        x = 2*T(rand()) - 1
-        legendre!(ctab_norm, plm_norm, LMAX, LMAX, x)
-        legendre!(ctab_sphr, plm_sphr, LMAX, LMAX, x)
-        @test all(isapprox.(nlm.*plm_norm, plm_sphr, atol=atol))
-    end
 end
 
 # Test failed with world age problems when generated functions were incorrectly used;

--- a/test/legendre.jl
+++ b/test/legendre.jl
@@ -35,68 +35,6 @@ end
     @test mmaxtab.ν == @view fulltab.ν[1:(MMAX+1)]
 end
 
-@testset "Domain checking" begin
-    LMAX = 10
-    MMAX = 2
-    ctab = LegendreUnitCoeff{Float64}(LMAX)
-    mtab = LegendreUnitCoeff{Float64}(LMAX, MMAX)
-    λ = Vector{Float64}(undef, LMAX+1)
-    Λ = Matrix{Float64}(undef, LMAX+1, LMAX+1)
-
-    # Mathematical domain errors:
-    @test_throws DomainError Pl(-1, 0.5)
-    @test_throws DomainError Plm(-1, 0, 0.5)
-    @test_throws DomainError Plm(LMAX, -1, 0.5)
-    @test_throws DomainError Plm(LMAX, LMAX+1, 0.5)
-    @test_throws DomainError Pl!(λ, -1, 0.5)
-    @test_throws DomainError Plm!(Λ, -1, 0, 0.5)
-    @test_throws DomainError Plm!(Λ, LMAX, -1, 0.5)
-    @test_throws DomainError Plm!(Λ, LMAX, LMAX+1, 0.5)
-    @test_throws DomainError legendre(ctab, -1, 0, 0.5)
-    @test_throws DomainError legendre(ctab, LMAX, -1, 0.5)
-    @test_throws DomainError legendre(ctab, LMAX, LMAX+1, 0.5)
-    @test_throws DomainError legendre!(ctab, λ, -1, LMAX, 0.5)
-    @test_throws DomainError legendre!(ctab, Λ, -1, LMAX, 0.5)
-    @test_throws DomainError legendre!(ctab, Λ, LMAX, -1, 0.5)
-    @test_throws DomainError legendre!(ctab, Λ, LMAX, LMAX+1, 0.5)
-
-    # Bounds error for precomputed coefficient tables
-    @test_throws BoundsError legendre(ctab, LMAX+1, 0, 0.5)
-    @test_throws BoundsError legendre(mtab, LMAX, MMAX+1, 0.5)
-    @test_throws BoundsError legendre!(mtab, λ, LMAX, MMAX+1, 0.5)
-    @test_throws BoundsError legendre!(mtab, Λ, LMAX, MMAX+1, 0.5)
-end
-
-@testset "Output array bounds checking" begin
-    LMAX = 2
-    ctab = LegendreUnitCoeff{Float64}(LMAX)
-    λ  = Vector{Float64}(undef, LMAX)
-    Λ₁ = Matrix{Float64}(undef, LMAX, LMAX+1)
-    Λ₂ = Matrix{Float64}(undef, LMAX+1, LMAX)
-
-    # Bounds error for filling vector or matrix
-    @test_throws DimensionMismatch Pl!(λ, LMAX, 0.5)
-    @test_throws DimensionMismatch Plm!(λ, LMAX, 0, 0.5)
-    @test_throws DimensionMismatch Plm!(Λ₁, LMAX, LMAX, 0.5)
-    @test_throws DimensionMismatch Plm!(Λ₂, LMAX, LMAX, 0.5)
-    @test_throws DimensionMismatch legendre!(ctab, λ, LMAX, 0, 0.5)
-    @test_throws DimensionMismatch legendre!(ctab, Λ₁, LMAX, LMAX, 0.5)
-    @test_throws DimensionMismatch legendre!(ctab, Λ₂, LMAX, LMAX, 0.5)
-
-    # Compatibility of output storage
-    Λ₃ = Array{Float64}(undef, 2, LMAX+1, LMAX+1)
-    Λ₄ = Array{Float64}(undef, 2, 2, LMAX+1, LMAX+1)
-    Λ₅ = Array{Float64}(undef, 2, 2, 2, LMAX+1, LMAX+1)
-    # Insufficient dimensions:
-    @test_throws DimensionMismatch Plm!(Λ₁, LMAX, LMAX, 0.0)
-    @test_throws DimensionMismatch Plm!(Λ₂, LMAX, LMAX, zeros(2))
-    @test_throws DimensionMismatch Plm!(Λ₃, LMAX, LMAX, zeros(2,2))
-    # Too many dimensions:
-    @test_throws DimensionMismatch Plm!(Λ₃, LMAX, LMAX, 0.0)
-    @test_throws DimensionMismatch Plm!(Λ₄, LMAX, LMAX, zeros(2))
-    @test_throws DimensionMismatch Plm!(Λ₅, LMAX, LMAX, zeros(2,2))
-end
-
 @testset "Functor interface" begin
     LMAX = 10
     leg = LegendreSphereCoeff{Float64}(LMAX)
@@ -237,18 +175,6 @@ end
     @test size(Plm.(LMAX, 0, z)) == sz
     @test size(Plm.(0:LMAX, 0, z)) == (sz..., LMAX+1)
     @test size(Plm.(0:LMAX, 0:LMAX, z)) == (sz..., LMAX+1, LMAX+1)
-
-    # Throws on invalid l ranges
-    @test_throws ArgumentError Pl.(1:LMAX, z)
-    @test_throws ArgumentError Plm.(1:LMAX, 0, z)
-    @test_throws ArgumentError λlm.(1:LMAX, 0, z)
-    @test_throws ArgumentError ctab.(1:LMAX, 0, z)
-    @test_throws ArgumentError legendre.(ctab, 1:LMAX, 0, z)
-    # Throws on invalid m ranges
-    @test_throws ArgumentError Plm.(0:LMAX, 1:LMAX, z)
-    @test_throws ArgumentError λlm.(0:LMAX, 1:LMAX, z)
-    @test_throws ArgumentError ctab.(0:LMAX, 1:LMAX, z)
-    @test_throws ArgumentError legendre.(ctab, 0:LMAX, 1:LMAX, z)
 end
 
 @testset "Numerical stability (issue #11)" begin

--- a/test/norms.jl
+++ b/test/norms.jl
@@ -1,0 +1,8 @@
+import ..TestSuite
+
+@testset "Unit normalization" begin
+    TestSuite.runtests(LegendreUnitNorm())
+end
+@testset "Spherical normalization" begin
+    TestSuite.runtests(LegendreSphereNorm())
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,11 +28,11 @@ macro include(file, desc)
 end
 
 @testset ExtendedTestSet "Legendre" begin
-    @include "scalar.jl" "Broadcastable scalar"
     @include "norms.jl" "Normalizations"
     @include "errors.jl" "Error checking"
     @include "coeffs.jl" "Precomputed coefficients"
     @include "analytic.jl" "Analytic checks"
-    @include "legendre.jl" "Legendre"
+    @include "implementation.jl" "Implementation details"
+    @include "scalar.jl" "Utility: scalar container"
     @include "doctests.jl" "Doctests"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,8 @@
 using Test, TestSetExtensions
 using Legendre # For doctests, include Legendre as a binding in Main
 
-const NumTypes = (Float32, Float64, BigFloat)
-
 include("testsuite.jl")
+using .TestSuite: NumTypes
 
 function prettytime(t)
     v, u = t < 1e3 ? (t, "ns") :
@@ -30,7 +29,9 @@ end
 
 @testset ExtendedTestSet "Legendre" begin
     @include "scalar.jl" "Broadcastable scalar"
+    @include "norms.jl" "Normalizations"
     @include "errors.jl" "Error checking"
+    @include "coeffs.jl" "Precomputed coefficients"
     @include "analytic.jl" "Analytic checks"
     @include "legendre.jl" "Legendre"
     @include "doctests.jl" "Doctests"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,7 @@ end
 
 @testset ExtendedTestSet "Legendre" begin
     @include "scalar.jl" "Broadcastable scalar"
+    @include "errors.jl" "Error checking"
     @include "analytic.jl" "Analytic checks"
     @include "legendre.jl" "Legendre"
     @include "doctests.jl" "Doctests"

--- a/test/scalar.jl
+++ b/test/scalar.jl
@@ -1,6 +1,3 @@
-module ScalarTest
-
-using Test
 using Legendre: Scalar
 
 @test Scalar{Float64}() isa Scalar{Float64}
@@ -35,5 +32,3 @@ s[Z] .= fill(5)
 s[I] .= fill(6)
 @test s[I] == fill(6)
 @test all(s[I] .+ 1 .== 7)
-
-end # module ScalarTest

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -1,13 +1,19 @@
 module TestSuite
     using Test, Legendre
-    export runtests
+    const LMAX = 5
+    const NumTypes = (Float32, Float64, BigFloat)
 
     function runtests(norm)
-        interface(norm)
+        @testset "Normalization $(typeof(norm))" begin
+            interface(norm)
+            promotion(norm)
+        end
     end
 
     function interface(norm)
-        @testset "Legendre Normalization ($norm)" begin
+        # Test all the aspects of the interface that each normalization type must
+        # implement
+        @testset "Legendre Interface" begin
             @test norm isa AbstractLegendreNorm
             # Initial condition
             @test isfinite(Legendre.Plm_00(norm, Float64))
@@ -17,6 +23,31 @@ module TestSuite
             # 2-term recurrence coefficients
             @test isfinite(Legendre.Plm_α(norm, Float64, 1, 0))
             @test isfinite(Legendre.Plm_β(norm, Float64, 1, 0))
+        end
+    end
+
+    function promotion(norm)
+        Λ₀ = fill(0.0)
+        Λ₁ = zeros(LMAX+1)
+        Λ₂ = zeros(LMAX+1, LMAX+1)
+        @testset "Argument eltype $T" for T in NumTypes
+            # 7 cases in recursion to handle:
+            #   1. Initial condition
+            #   2. Boost along diagonal from (even,even) -> (odd,odd)
+            #      2a. Boost in ℓ from (m,m) -> (m+1, m)
+            #      2b. Boost again in ℓ from (m+1,m) -> (m+2, m)
+            #   3. Repeat (2) but for step along diagonal from (odd,odd) -> (even,even)
+            cases = ((0,0), (1,1), (2,1), (3,1), (2,2), (3,2), (4,2))
+            @testset "(ℓ,m) == ($ℓ, $m)" for (ℓ, m) in cases
+                # Return type matches that of the argument, even though internal calculation
+                # will promote.
+                @test @inferred(legendre(norm, ℓ, m, one(T))) isa T
+                # Also must handle single value, all ℓ for fixed m, and all (ℓ,m) up to
+                # (LMAX,LMAX)
+                @test @inferred(legendre!(norm, Λ₀, LMAX, LMAX, one(T))) isa typeof(Λ₀)
+                @test @inferred(legendre!(norm, Λ₁, LMAX, LMAX, one(T))) isa typeof(Λ₁)
+                @test @inferred(legendre!(norm, Λ₂, LMAX, LMAX, one(T))) isa typeof(Λ₂)
+            end
         end
     end
 end

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -1,0 +1,22 @@
+module TestSuite
+    using Test, Legendre
+    export runtests
+
+    function runtests(norm)
+        interface(norm)
+    end
+
+    function interface(norm)
+        @testset "Legendre Normalization ($norm)" begin
+            @test norm isa AbstractLegendreNorm
+            # Initial condition
+            @test isfinite(Legendre.Plm_00(norm, Float64))
+            # 1-term recurrence coefficients
+            @test isfinite(Legendre.Plm_μ(norm, Float64, 1))
+            @test isfinite(Legendre.Plm_ν(norm, Float64, 1))
+            # 2-term recurrence coefficients
+            @test isfinite(Legendre.Plm_α(norm, Float64, 1, 0))
+            @test isfinite(Legendre.Plm_β(norm, Float64, 1, 0))
+        end
+    end
+end


### PR DESCRIPTION
Rearrange the single-file testing into a set of files with different focus. This is just to make further development a bit easier by more clearly delineating what is part of the public interface and what should be considered an implementation detail.

In reviewing, I think there are actually a few tests that are wrong or should be changed with some corresponding API changes, but those will be fixed in follow-up PRs.