### PR TITLE
Various cleanups

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,7 @@
 using Documenter, Legendre
 
-doctest = "--fix" in ARGS ? :fix : false
+doctest = "--fix"  in ARGS ? :fix :
+          "--test" in ARGS ? true : false
 
 DocMeta.setdocmeta!(Legendre, :DocTestSetup, :(using Legendre); recursive=true)
 
@@ -16,9 +17,11 @@ makedocs(
     ],
     pages = [
         "Legendre.jl Documentation" => "index.md",
-        "Manual" => [
-            "Legendre Functions" => "man/legendre.md",
-            "References" => "man/references.md"
+        "Associated Legendre Functions" => [
+            "Introduction" => "man/intro.md",
+            "Usage" => "man/usage.md",
+            "Developer Documentation" => "man/devdocs.md",
+            "Literature/References" => "man/references.md"
         ],
         "API Reference" => [
             "Public" => "lib/public.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,7 +12,9 @@ Design goals of this package include:
 ## User Manual and Documentation
 ```@contents
 Pages = [
-    "man/legendre.md",
+    "man/intro.md",
+    "man/usage.md",
+    "man/devdocs.md",
     "man/references.md"
 ]
 Depth = 1
@@ -31,4 +33,3 @@ Depth = 1
 ```@index
 Pages = ["lib/public.md"]
 ```
-

--- a/docs/src/man/devdocs.md
+++ b/docs/src/man/devdocs.md
@@ -21,14 +21,23 @@ normalization is added by simply extending appropriate types and methods.
 The following table lists all of the types to extend and method specialization to
 implement.
 
-| Interfaces to extend/implement              | Brief description                                                              |
-|:------------------------------------------- |:------------------------------------------------------------------------------ |
-| [`Legendre.AbstractLegendreNorm`](@ref) | Supertype of normalization trait types                                         |
-| [`Legendre.Plm_00()`](@ref)             | Value of ``N_0^0 P_0^0(x)`` for the given normalization                        |
-| [`Legendre.Plm_μ()`](@ref)              | Coefficient ``μ_m`` for the 1-term r.r. boosting ``ℓ → ℓ+1`` and ``m → m+1``   |
-| [`Legendre.Plm_ν()`](@ref)              | Coefficient ``ν_m`` for the 1-term r.r. boosting ``ℓ → ℓ+1``                   |
-| [`Legendre.Plm_α()`](@ref)              | Coefficient ``α_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ,m)`` term         |
-| [`Legendre.Plm_β()`](@ref)              | Coefficient ``β_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ-1,m)`` term       |
+### Normalization Interface
+
+| Interfaces to extend/implement          | Brief description                                                            |
+|:--------------------------------------- |:---------------------------------------------------------------------------- |
+| [`Legendre.AbstractLegendreNorm`](@ref) | Supertype of normalization trait types                                       |
+| [`Legendre.Plm_00()`](@ref)             | Value of ``N_0^0 P_0^0(x)`` for the given normalization                      |
+| [`Legendre.Plm_μ()`](@ref)              | Coefficient ``μ_m`` for the 1-term r.r. boosting ``ℓ → ℓ+1`` and ``m → m+1`` |
+| [`Legendre.Plm_ν()`](@ref)              | Coefficient ``ν_m`` for the 1-term r.r. boosting ``ℓ → ℓ+1``                 |
+| [`Legendre.Plm_α()`](@ref)              | Coefficient ``α_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ,m)`` term       |
+| [`Legendre.Plm_β()`](@ref)              | Coefficient ``β_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ-1,m)`` term     |
+
+| Optional interfaces                 | Brief description                      |
+|:----------------------------------- |:-------------------------------------- |
+| [`Legendre.boundscheck_hook()`](@ref) | Hook to participate in bounds checking |
+
+
+### Example implementation
 
 As a concrete example, we'll walk through how ``λ_ℓ^m(x)`` is defined to have the
 spherical harmonic normalization baked in.

--- a/docs/src/man/devdocs.md
+++ b/docs/src/man/devdocs.md
@@ -1,0 +1,176 @@
+# Developer Documentation
+
+```@meta
+DocTestFilters = Regex[
+        r"Ptr{0x[0-9a-f]+}",
+        r"[0-9\.]+ seconds( \(.*\))?",
+        ]
+```
+
+```@contents
+Pages = ["devdocs.md"]
+Depth = 2
+```
+
+## [Custom normalizations](@id customnorm)
+`Legendre` provides the standard and spherical harmonic normalizations by default, but
+arbitrary normalizations are also supported.
+The mile-high overview is that the initial condition and recurrence relation (r.r.)
+coefficients are all methods which dispatch on a normalization trait type, so a new
+normalization is added by simply extending appropriate types and methods.
+The following table lists all of the types to extend and method specialization to
+implement.
+
+| Interfaces to extend/implement              | Brief description                                                              |
+|:------------------------------------------- |:------------------------------------------------------------------------------ |
+| [`Legendre.AbstractLegendreNorm`](@ref) | Supertype of normalization trait types                                         |
+| [`Legendre.Plm_00()`](@ref)             | Value of ``N_0^0 P_0^0(x)`` for the given normalization                        |
+| [`Legendre.Plm_μ()`](@ref)              | Coefficient ``μ_m`` for the 1-term r.r. boosting ``ℓ → ℓ+1`` and ``m → m+1``   |
+| [`Legendre.Plm_ν()`](@ref)              | Coefficient ``ν_m`` for the 1-term r.r. boosting ``ℓ → ℓ+1``                   |
+| [`Legendre.Plm_α()`](@ref)              | Coefficient ``α_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ,m)`` term         |
+| [`Legendre.Plm_β()`](@ref)              | Coefficient ``β_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ-1,m)`` term       |
+
+As a concrete example, we'll walk through how ``λ_ℓ^m(x)`` is defined to have the
+spherical harmonic normalization baked in.
+
+```math
+\begin{align}
+    λ_ℓ^m(x) &≡ N_ℓ^m P_ℓ^m(x)
+    \\
+    N_ℓ^m &= \sqrt{\frac{2ℓ+1}{4π} \frac{(ℓ-m)!}{(ℓ+m)!}}
+\end{align}
+```
+
+Baking in the normalization happens by changing the coefficients in the recursion
+relations given in the [Definitions and Properties](@ref legendre_defn) section.
+For our purposes, they take on the form:
+```math
+\begin{align}
+    P_{\ell+1}^m(x) &= \alpha_{\ell+1}^m x P_\ell^m(x)
+        - \beta_{\ell+1}^m P_{\ell-1}^m(x)
+        \label{eqn:cus_rr_2term}
+    \\
+    P_{m+1}^{m+1}(x) &= \mu_{m+1} \sqrt{1-x^2} P_m^m(x)
+        \label{eqn:cus_rr_1term_lm}
+    \\
+    P_{m+1}^m(x) &= \nu_m x P_m^m(x)
+        \label{eqn:cus_rr_1term_l}
+\end{align}
+```
+The normalization is encoded in the coefficients ``α_ℓ^m``, ``β_ℓ^m``, ``μ_m``, and
+``ν_m``.
+For the standard (unity) normalization, these take on the values
+```math
+\begin{align}
+    α_ℓ^m &= \frac{2ℓ - 1}{ℓ - m} \\
+    β_ℓ^m &= \frac{ℓ + m - 1}{ℓ - m} \\
+    μ_m &= 2ℓ - 1 \\
+    ν_m &= 2ℓ + 1
+\end{align}
+```
+by simply identifying the coefficients from Eqns.
+``\ref{eqn:cus_rr_2term}``–``\ref{eqn:cus_rr_1term_l}`` on each of the ``P_ℓ^m(x)`` terms
+on the right hand side.
+For other normalizations, we multiply through by the normalization factor
+appropriate for the left-hand side of the equations, rearrange terms to
+correctly normalize the terms on the right, and identify the coefficients left
+over.
+For example, ``α_ℓ^m`` and ``β_ℓ^m`` for ``λ_ℓ^m(x)`` are determined by starting with
+Eq. ``\ref{eqn:cus_rr_2term}`` and multiply through by ``N_{ℓ+1}^m``.
+The left-hand side by definition is ``λ_{ℓ+1}^m``, leaving us with
+```math
+\begin{align}
+    \begin{split}
+        λ_{ℓ+1}^m &= \frac{2ℓ + 1}{ℓ - m + 1} x
+            \sqrt{\frac{2ℓ+3}{4π} \frac{(ℓ-m+1)!}{(ℓ+m+1)!}} P_ℓ^m(x) -
+            \\
+            &\quad\quad \frac{ℓ+m}{ℓ-m+1} \sqrt{\frac{2ℓ+3}{4π}
+            \frac{(ℓ-m+1)!}{(ℓ+m+1)!}} P_{ℓ-1}^m(x)
+    \end{split}
+\end{align}
+```
+Through judicious use of algebra, the terms on the right-hand side can be manipulated
+to gather terms of the form ``N_ℓ^m P_ℓ^m(x)`` and ``N_{ℓ-1}^m P_{ℓ-1}^m(x)``, leaving us
+with
+```math
+\begin{align}
+    λ_{ℓ+1}^m &= \sqrt{\frac{2ℓ+3}{2ℓ-1} \frac{4ℓ^2 - 1}{(ℓ+1)^2 - m^2}} x
+        λ_ℓ^m(x) -
+        \sqrt{\frac{2ℓ+3}{2ℓ-1} \frac{ℓ^2 - m^2}{(ℓ+1)^2 - m^2}}
+        λ_{ℓ-1}^m(x)
+\end{align}
+```
+We identify each of the two square root terms as ``α_{ℓ+1}^m`` and ``β_{ℓ+1}^m`` since
+they are the cofficients appropriate for generating ``λ_{ℓ+1}^m(x)``.
+Doing so with the other two recurrence relation equations, we obtain:
+```math
+\begin{align}
+    α_ℓ^m &= \sqrt{\frac{2ℓ+1}{2ℓ-3} \frac{4(ℓ-1)^2 - 1}{ℓ^2 - m^2}} \\
+    β_ℓ^m &= \sqrt{\frac{2ℓ+1}{2ℓ-3} \frac{(ℓ-1)^2 - m^2}{ℓ^2 - m^2}} \\
+    μ_m &= \sqrt{1 + \frac{1}{2m}} \\
+    ν_m &= \sqrt{2m + 3}
+\end{align}
+```
+The final math required is to define the initial condition ``λ_0^0(x)``.
+This is straight forward given the definition:
+```math
+\begin{align}
+    λ_0^0(x) &= N_0^0 P_0^0(x) = \sqrt{\frac{1}{4π}} × 1 \\
+    λ_0^0(x) &= \sqrt{\frac{1}{4π}}
+\end{align}
+```
+
+We now have all the information required to define a custom Legendre normalization.
+Begin by importing the types and methods which will need to be extended:
+```jldoctest λNorm
+julia> using Legendre
+
+julia> import Legendre: AbstractLegendreNorm, Plm_00, Plm_μ, Plm_ν, Plm_α, Plm_β
+```
+We'll call our new normalization `λNorm`, which must be a subclass of
+`AbstractLegendreNorm`.
+```jldoctest λNorm
+julia> struct λNorm <: AbstractLegendreNorm end
+```
+The initial condition is specified by providing a method of `Plm_00` which takes our
+normalization trait type as the first argument.
+(The second argument can be useful if some extra type information is required to set
+up a type-stable algorithm, which we'll ignore here for the sake of simplicity.)
+```jldoctest λNorm
+julia> Plm_00(::λNorm, T::Type) = sqrt(1 / 4π)
+Plm_00 (generic function with 4 methods)
+```
+Finally, we provide methods which encode the cofficients as well:
+```jldoctest λNorm
+julia> function Plm_α(::λNorm, T::Type, l::Integer, m::Integer)
+           fac1 = (2l + 1) / ((2l - 3) * (l^2 - m^2))
+           fac2 = 4*(l-1)^2 - 1
+           return sqrt(fac1 * fac2)
+       end
+Plm_α (generic function with 4 methods)
+
+julia> function Plm_β(::λNorm, T::Type, l::Integer, m::Integer)
+           fac1 = (2l + 1) / ((2l - 3) * (l^2 - m^2))
+           fac2 = (l-1)^2 - m^2
+           return sqrt(fac1 * fac2)
+       end
+Plm_β (generic function with 4 methods)
+
+julia> Plm_μ(::λNorm, T::Type, m::Integer) = sqrt(1 + 1 / 2m)
+Plm_μ (generic function with 4 methods)
+
+julia> Plm_ν(::λNorm, T::Type, m::Integer) = sqrt(3 + 2m)
+Plm_ν (generic function with 4 methods)
+```
+
+With just those 5 methods provided, the full Legendre framework is available,
+including precomputing the coefficients.
+```jldoctest λNorm
+julia> legendre(λNorm(), 700, 500, 0.4)
+0.35366224602811
+
+julia> coeff = LegendreNormCoeff{λNorm,Float64}(700);
+
+julia> legendre(coeff, 700, 500, 0.4)
+0.35366224602811
+```

--- a/docs/src/man/intro.md
+++ b/docs/src/man/intro.md
@@ -1,0 +1,68 @@
+# [Introduction](@id intro)
+
+```@contents
+Pages = ["intro.md"]
+Depth = 2
+```
+
+## [Definition and Properties](@id legendre_defn)
+
+The associated Legendre polynomials ``P_ℓ^m(x)`` are the solution to the differential
+equation
+```math
+\begin{align}
+    (1-x^2) \frac{d^2}{dx^2}P_ℓ^m(x) - 2x \frac{d}{dx}P_ℓ^m(x) + \left[ ℓ(ℓ+1) -
+        \frac{m^2}{1-x^2} \right] P_ℓ^m(x) = 0
+\end{align}
+```
+which arises as the colatitude ``θ`` part of solving Laplace's equation
+``∇^2 ψ + λψ = 0`` in spherical coordinates (where ``x = \cos(θ)``).
+
+There are several different conventions used to define ``P_ℓ^m`` that provide
+different properties, but the convention used here is typical of quantum
+mechanics and obeys the following properties:
+
+* Solutions only exist for integer ``ℓ`` and ``m``, where ``ℓ ≤ 0`` and ``|m| ≤ ℓ``.
+
+* The associated Legendre functions are normalized such that ``P_0^0`` is unity and have
+  orthogonality conditions,
+  ```math
+  \begin{align}
+      \int_{-1}^1 P_ℓ^m(x) P_{ℓ'}^{m}(x)\,\mathrm{d}x
+          = \frac{2}{2ℓ+1} \frac{(ℓ+m)!}{(ℓ-m)!}
+          \delta_{ℓℓ'}
+  \end{align}
+  ```
+  for constant ``m`` and
+  ```math
+  \begin{align}
+      \int_{-1}^1 \frac{P_ℓ^m(x) P_{ℓ}^{m'}(x)}{1-x^2}\,\mathrm{d}x
+          = \frac{1}{m} \frac{(ℓ+m)!}{(ℓ-m)!} \delta_{mm'}
+  \end{align}
+  ```
+  for constant ``ℓ``, where ``δ`` is the Kronecker delta.
+
+* The phase convention for the Legendre functions is chosen such that the negative orders
+  are related to positive orders according to,
+  ```math
+  \begin{align}
+      P_ℓ^{-m}(x) = (-1)^m \frac{(ℓ-m)!}{(ℓ+m)!} P_ℓ^m(x)
+  \end{align}
+  ```
+
+* The Legendre functions can be enumerated for non-negative ``m`` using the three
+  following recursion relations (given the initial condition ``P_0^0(x)``):
+  ```math
+  \begin{align}
+      (ℓ - m + 1)P_{ℓ+1}^m(x) &= (2ℓ+1)xP_ℓ^m(x) - (ℓ+m)P_{ℓ-1}^m(x)
+      \label{eqn:std_rr_2term}
+      \\
+      P_{ℓ+1}^{ℓ+1}(x) &= -(2ℓ+1)\sqrt{1-x^2} P_ℓ^ℓ(x)
+      \label{eqn:std_rr_1term_lm}
+      \\
+      P_{ℓ+1}^ℓ(x) &= x(2ℓ+1)P_ℓ^ℓ(x)
+      \label{eqn:std_rr_1term_l}
+  \end{align}
+  ```
+
+

--- a/docs/src/man/references.md
+++ b/docs/src/man/references.md
@@ -7,6 +7,9 @@
   In: *Proceedings of the 40th Congress on Science and Technology of Thailand* (Dec 2014)
   arXiv: [1410.1748](https://arxiv.org/abs/1410.1748v1)
 
+* “Legendre and Related Functions” [(Chapter 14)](https://dlmf.nist.gov/14)
+  In: *NIST Digital Library of Mathematical Functions*
+
 * “Legendre polynomials” on
   [*Wikipedia*](https://en.wikipedia.org/wiki/Legendre_polynomials)
   and

--- a/docs/src/man/usage.md
+++ b/docs/src/man/usage.md
@@ -1,4 +1,4 @@
-# [Legendre Polynomials](@id man_legendre)
+# [Usage](@id usage)
 ```@meta
 DocTestFilters = Regex[
         r"Ptr{0x[0-9a-f]+}",
@@ -7,76 +7,11 @@ DocTestFilters = Regex[
 ```
 
 ```@contents
-Pages = ["legendre.md"]
+Pages = ["usage.md"]
 Depth = 2
 ```
 
-The [`Legendre`](@ref Legendre.Legendre) module implementation has been largely based on the approach of
-[Limpanuparb and Milthorpe (2014)](@ref bib-legendre).
-
-## [Definition and Properties](@id legendre_defn)
-
-The associated Legendre polynomials ``P_ℓ^m(x)`` are the solution to the differential
-equation
-```math
-\begin{align}
-    (1-x^2) \frac{d^2}{dx^2}P_ℓ^m(x) - 2x \frac{d}{dx}P_ℓ^m(x) + \left[ ℓ(ℓ+1) -
-        \frac{m^2}{1-x^2} \right] P_ℓ^m(x) = 0
-\end{align}
-```
-which arises as the colatitude ``θ`` part of solving Laplace's equation
-``∇^2 ψ + λψ = 0`` in spherical coordinates (where ``x = \cos(θ)``).
-
-There are several different conventions used to define ``P_ℓ^m`` that provide
-different properties, but the convention used here is typical of quantum
-mechanics and obeys the following properties:
-
-* Solutions only exist for integer ``ℓ`` and ``m``, where ``ℓ ≤ 0`` and ``|m| ≤ ℓ``.
-
-* The associated Legendre functions are normalized such that ``P_0^0`` is unity and have
-  orthogonality conditions,
-  ```math
-  \begin{align}
-      \int_{-1}^1 P_ℓ^m(x) P_{ℓ'}^{m}(x)\,\mathrm{d}x
-          = \frac{2}{2ℓ+1} \frac{(ℓ+m)!}{(ℓ-m)!}
-          \delta_{ℓℓ'}
-  \end{align}
-  ```
-  for constant ``m`` and
-  ```math
-  \begin{align}
-      \int_{-1}^1 \frac{P_ℓ^m(x) P_{ℓ}^{m'}(x)}{1-x^2}\,\mathrm{d}x
-          = \frac{1}{m} \frac{(ℓ+m)!}{(ℓ-m)!} \delta_{mm'}
-  \end{align}
-  ```
-  for constant ``ℓ``, where ``δ`` is the Kronecker delta.
-
-* The phase convention for the Legendre functions is chosen such that the negative orders
-  are related to positive orders according to,
-  ```math
-  \begin{align}
-      P_ℓ^{-m}(x) = (-1)^m \frac{(ℓ-m)!}{(ℓ+m)!} P_ℓ^m(x)
-  \end{align}
-  ```
-
-* The Legendre functions can be enumerated for non-negative ``m`` using the three
-  following recursion relations (given the initial condition ``P_0^0(x)``):
-  ```math
-  \begin{align}
-      (ℓ - m + 1)P_{ℓ+1}^m(x) &= (2ℓ+1)xP_ℓ^m(x) - (ℓ+m)P_{ℓ-1}^m(x)
-      \label{eqn:std_rr_2term}
-      \\
-      P_{ℓ+1}^{ℓ+1}(x) &= -(2ℓ+1)\sqrt{1-x^2} P_ℓ^ℓ(x)
-      \label{eqn:std_rr_1term_lm}
-      \\
-      P_{ℓ+1}^ℓ(x) &= x(2ℓ+1)P_ℓ^ℓ(x)
-      \label{eqn:std_rr_1term_l}
-  \end{align}
-  ```
-
-## [Usage](@id legendre_usage)
-
-### Calculating scalar values
+## Calculating scalar values
 
 At its simplest, the associated Legendre polynomial ``P_ℓ^m(x)`` is computed by calling
 [`Legendre.Plm`](@ref). For example, to compute ``P_2^1(0.5)``,
@@ -155,9 +90,9 @@ julia> λlm(157, 150, 0.5)
     We are not just limited to efficient and numerically stable computation of
     ``λ_ℓ^m(x)``; the package supports arbitrary normalizations.  For further
     information on implementing custom Legendre normalizations, see the [Custom
-    normalizations](@ref legendre_customnorm) section.
+    normalizations](@ref customnorm) section.
 
-### Calculating all values up to a given ``ℓ_\mathrm{max}``
+## Calculating all values up to a given ``ℓ_\mathrm{max}``
 
 Because calculating a particular Legendre polynomial value is the end result of running
 a recurrence relation, looping evaluation of ``P_ℓ^m(x)`` for all ``ℓ`` is inefficient and
@@ -192,7 +127,7 @@ julia> Λ[701,3] == λlm(700, 2, 0.5)   # N.B. 1-based indexing of the array!
 true
 ```
 
-### Broadcasting over multiple arguments
+## Broadcasting over multiple arguments
 
 The Legendre polynomials can be evaluated over multiple arguments ``x`` as well by
 using Julia's standard broadcasting syntax:
@@ -257,7 +192,7 @@ switching to `m` a `UnitRange` as well, the output dimensionality is two greater
 `z`, with the penultimate and final dimensions running over ``\ell`` and ``m``,
 respectively.
 
-### Precomputed recursion factors
+## Precomputed recursion factors
 
 A final trick to accelerating calculation of any normalization of the associated
 Legendre polynomials is to pre-compute the appropriate recursion relation coefficients.
@@ -318,172 +253,9 @@ julia> Λ[1:5, 1:5]
   0.0         0.0       0.0       0.0  0.0
 ```
 
-## [Custom normalizations](@id legendre_customnorm)
-`Legendre` provides the standard and spherical harmonic normalizations by default, but
-arbitrary normalizations are also supported.
-The mile-high overview is that the initial condition and recurrence relation (r.r.)
-coefficients are all methods which dispatch on a normalization trait type, so a new
-normalization is added by simply extending appropriate types and methods.
-The following table lists all of the types to extend and method specialization to
-implement.
-
-| Interfaces to extend/implement              | Brief description                                                              |
-|:------------------------------------------- |:------------------------------------------------------------------------------ |
-| [`Legendre.AbstractLegendreNorm`](@ref) | Supertype of normalization trait types                                         |
-| [`Legendre.Plm_00()`](@ref)             | Value of ``N_0^0 P_0^0(x)`` for the given normalization                        |
-| [`Legendre.Plm_μ()`](@ref)              | Coefficient ``μ_m`` for the 1-term r.r. boosting ``ℓ → ℓ+1`` and ``m → m+1``   |
-| [`Legendre.Plm_ν()`](@ref)              | Coefficient ``ν_m`` for the 1-term r.r. boosting ``ℓ → ℓ+1``                   |
-| [`Legendre.Plm_α()`](@ref)              | Coefficient ``α_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ,m)`` term         |
-| [`Legendre.Plm_β()`](@ref)              | Coefficient ``β_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ-1,m)`` term       |
-
-As a concrete example, we'll walk through how ``λ_ℓ^m(x)`` is defined to have the
-spherical harmonic normalization baked in.
-
-```math
-\begin{align}
-    λ_ℓ^m(x) &≡ N_ℓ^m P_ℓ^m(x)
-    \\
-    N_ℓ^m &= \sqrt{\frac{2ℓ+1}{4π} \frac{(ℓ-m)!}{(ℓ+m)!}}
-\end{align}
-```
-
-Baking in the normalization happens by changing the coefficients in the recursion
-relations given in the [Definitions and Properties](@ref legendre_defn) section.
-For our purposes, they take on the form:
-```math
-\begin{align}
-    P_{\ell+1}^m(x) &= \alpha_{\ell+1}^m x P_\ell^m(x)
-        - \beta_{\ell+1}^m P_{\ell-1}^m(x)
-        \label{eqn:cus_rr_2term}
-    \\
-    P_{m+1}^{m+1}(x) &= \mu_{m+1} \sqrt{1-x^2} P_m^m(x)
-        \label{eqn:cus_rr_1term_lm}
-    \\
-    P_{m+1}^m(x) &= \nu_m x P_m^m(x)
-        \label{eqn:cus_rr_1term_l}
-\end{align}
-```
-The normalization is encoded in the coefficients ``α_ℓ^m``, ``β_ℓ^m``, ``μ_m``, and
-``ν_m``.
-For the standard (unity) normalization, these take on the values
-```math
-\begin{align}
-    α_ℓ^m &= \frac{2ℓ - 1}{ℓ - m} \\
-    β_ℓ^m &= \frac{ℓ + m - 1}{ℓ - m} \\
-    μ_m &= 2ℓ - 1 \\
-    ν_m &= 2ℓ + 1
-\end{align}
-```
-by simply identifying the coefficients from Eqns.
-``\ref{eqn:std_rr_2term}``–``\ref{eqn:std_rr_1term_l}`` on each of the ``P_ℓ^m(x)`` terms
-on the right hand side.
-For other normalizations, we multiply through by the normalization factor
-appropriate for the left-hand side of the equations, rearrange terms to
-correctly normalize the terms on the right, and identify the coefficients left
-over.
-For example, ``α_ℓ^m`` and ``β_ℓ^m`` for ``λ_ℓ^m(x)`` are determined by starting with
-Eq. ``\ref{eqn:std_rr_2term}`` and multiply through by ``N_{ℓ+1}^m``.
-The left-hand side by definition is ``λ_{ℓ+1}^m``, leaving us with
-```math
-\begin{align}
-    \begin{split}
-        λ_{ℓ+1}^m &= \frac{2ℓ + 1}{ℓ - m + 1} x
-            \sqrt{\frac{2ℓ+3}{4π} \frac{(ℓ-m+1)!}{(ℓ+m+1)!}} P_ℓ^m(x) -
-            \\
-            &\quad\quad \frac{ℓ+m}{ℓ-m+1} \sqrt{\frac{2ℓ+3}{4π}
-            \frac{(ℓ-m+1)!}{(ℓ+m+1)!}} P_{ℓ-1}^m(x)
-    \end{split}
-\end{align}
-```
-Through judicious use of algebra, the terms on the right-hand side can be manipulated
-to gather terms of the form ``N_ℓ^m P_ℓ^m(x)`` and ``N_{ℓ-1}^m P_{ℓ-1}^m(x)``, leaving us
-with
-```math
-\begin{align}
-    λ_{ℓ+1}^m &= \sqrt{\frac{2ℓ+3}{2ℓ-1} \frac{4ℓ^2 - 1}{(ℓ+1)^2 - m^2}} x
-        λ_ℓ^m(x) -
-        \sqrt{\frac{2ℓ+3}{2ℓ-1} \frac{ℓ^2 - m^2}{(ℓ+1)^2 - m^2}}
-        λ_{ℓ-1}^m(x)
-\end{align}
-```
-We identify each of the two square root terms as ``α_{ℓ+1}^m`` and ``β_{ℓ+1}^m`` since
-they are the cofficients appropriate for generating ``λ_{ℓ+1}^m(x)``.
-Doing so with the other two recurrence relation equations, we obtain:
-```math
-\begin{align}
-    α_ℓ^m &= \sqrt{\frac{2ℓ+1}{2ℓ-3} \frac{4(ℓ-1)^2 - 1}{ℓ^2 - m^2}} \\
-    β_ℓ^m &= \sqrt{\frac{2ℓ+1}{2ℓ-3} \frac{(ℓ-1)^2 - m^2}{ℓ^2 - m^2}} \\
-    μ_m &= \sqrt{1 + \frac{1}{2m}} \\
-    ν_m &= \sqrt{2m + 3}
-\end{align}
-```
-The final math required is to define the initial condition ``λ_0^0(x)``.
-This is straight forward given the definition:
-```math
-\begin{align}
-    λ_0^0(x) &= N_0^0 P_0^0(x) = \sqrt{\frac{1}{4π}} × 1 \\
-    λ_0^0(x) &= \sqrt{\frac{1}{4π}}
-\end{align}
-```
-
-We now have all the information required to define a custom Legendre normalization.
-Begin by importing the types and methods which will need to be extended:
-```jldoctest λNorm
-julia> using Legendre
-
-julia> import Legendre: AbstractLegendreNorm, Plm_00, Plm_μ, Plm_ν, Plm_α, Plm_β
-```
-We'll call our new normalization `λNorm`, which must be a subclass of
-`AbstractLegendreNorm`.
-```jldoctest λNorm
-julia> struct λNorm <: AbstractLegendreNorm end
-```
-The initial condition is specified by providing a method of `Plm_00` which takes our
-normalization trait type as the first argument.
-(The second argument can be useful if some extra type information is required to set
-up a type-stable algorithm, which we'll ignore here for the sake of simplicity.)
-```jldoctest λNorm
-julia> Plm_00(::λNorm, T::Type) = sqrt(1 / 4π)
-Plm_00 (generic function with 4 methods)
-```
-Finally, we provide methods which encode the cofficients as well:
-```jldoctest λNorm
-julia> function Plm_α(::λNorm, T::Type, l::Integer, m::Integer)
-           fac1 = (2l + 1) / ((2l - 3) * (l^2 - m^2))
-           fac2 = 4*(l-1)^2 - 1
-           return sqrt(fac1 * fac2)
-       end
-Plm_α (generic function with 4 methods)
-
-julia> function Plm_β(::λNorm, T::Type, l::Integer, m::Integer)
-           fac1 = (2l + 1) / ((2l - 3) * (l^2 - m^2))
-           fac2 = (l-1)^2 - m^2
-           return sqrt(fac1 * fac2)
-       end
-Plm_β (generic function with 4 methods)
-
-julia> Plm_μ(::λNorm, T::Type, m::Integer) = sqrt(1 + 1 / 2m)
-Plm_μ (generic function with 4 methods)
-
-julia> Plm_ν(::λNorm, T::Type, m::Integer) = sqrt(3 + 2m)
-Plm_ν (generic function with 4 methods)
-```
-
-With just those 5 methods provided, the full Legendre framework is available,
-including precomputing the coefficients.
-```jldoctest λNorm
-julia> legendre(λNorm(), 700, 500, 0.4)
-0.35366224602811
-
-julia> coeff = LegendreNormCoeff{λNorm,Float64}(700);
-
-julia> legendre(coeff, 700, 500, 0.4)
-0.35366224602811
-```
-
 ---
 
-### Footnotes
+## Footnotes
 
 [^1]:
     Specifically, the envelope of ``P_ℓ^m(x)`` which bounds the local extrema

--- a/src/Legendre.jl
+++ b/src/Legendre.jl
@@ -26,7 +26,7 @@ export legendre, legendre!
 include("calculation.jl")
 
 # Other functionality
-export Pl, Pl!, Plm, Plm!, Nlm, λlm, λlm!
+export Plm, Plm!, Nlm, λlm, λlm!
 include("aliases.jl")
 include("broadcasting.jl")
 

--- a/src/broadcasting.jl
+++ b/src/broadcasting.jl
@@ -9,7 +9,7 @@ function broadcasted(::typeof(legendre),
     z = Broadcast.materialize(x)
     Λ = _similar(z)
     _chkdomain(l, m)
-    _chkdomainnorm(norm, l, m)
+    boundscheck_hook(norm, l, m)
     @inbounds _legendre!(norm, Λ, l, m, z)
     return (ndims(Λ) == 0) ? Λ[] : Λ
 end
@@ -26,7 +26,7 @@ function broadcasted(::typeof(legendre),
     lmax = last(l)
     mmax = m isa UnitRange ? last(m) : m
     _chkdomain(lmax, mmax)
-    _chkdomainnorm(norm, lmax, mmax)
+    boundscheck_hook(norm, lmax, mmax)
     @inbounds _legendre!(norm, Λ, lmax, mmax, z)
     return Λ
 end

--- a/src/calculation.jl
+++ b/src/calculation.jl
@@ -49,21 +49,21 @@ end
     return Λ
 end
 
-@inline _similar(A::AbstractArray) = similar(A, size(A))
-@inline _similar(A::Number)        = Scalar{typeof(A)}()
+@inline _similar(A::AbstractArray, ::Type{T}=eltype(A)) where {T} = similar(A, T, size(A))
+@inline _similar(A::Number, ::Type{T}=typeof(A)) where {T}        = Scalar{T}()
 @propagate_inbounds function _legendre_impl!(norm::AbstractLegendreNorm, Λ, lmax, mmax, x)
     TΛ = eltype(Λ)
     TV = eltype(x)
     T = promote_type(eltype(norm), TΛ, TV)
 
-    z    = _similar(x)
-    y¹   = _similar(x)
-    y²   = _similar(x)
-    pm   = _similar(x)
-    pmp2 = _similar(x)
-    plm1 = _similar(x)
-    pl   = _similar(x)
-    plp1 = _similar(x)
+    z    = _similar(x, T)
+    y¹   = _similar(x, T)
+    y²   = _similar(x, T)
+    pm   = _similar(x, T)
+    pmp2 = _similar(x, T)
+    plm1 = _similar(x, T)
+    pl   = _similar(x, T)
+    plp1 = _similar(x, T)
 
     @. z = convert(T, x)
     @. y² = -fma(z, z, -one(T))

--- a/src/calculation.jl
+++ b/src/calculation.jl
@@ -211,7 +211,7 @@ dimensions having the same shape as `x`.
   and `Λ` is filled with polynomial values for all degrees `0 ≤ l ≤ lmax` and orders
   `0 ≤ m ≤ min(mmax, l)`.
 """
-@propagate_inbounds function legendre!(
+function legendre!(
         norm::AbstractLegendreNorm,
         Λ, l::Integer, m::Integer, x)
     return _legendre!(norm, Λ, l, m, x)

--- a/src/calculation.jl
+++ b/src/calculation.jl
@@ -1,8 +1,3 @@
-@inline _chkdomainnorm(norm::AbstractLegendreNorm, lmax, mmax) = nothing
-@noinline function _chkdomainnorm(norm::LegendreNormCoeff, lmax, mmax)
-    lmax′,mmax′ = size(norm.α)
-    (lmax < lmax′ && mmax < mmax′) || throw(BoundsError(norm.α, (lmax+1, mmax+1)))
-end
 @noinline function _chkdomain(lmax, mmax)
     0 ≤ lmax || throw(DomainError(lmax, "degree lmax must be non-negative"))
     0 ≤ mmax ≤ lmax || throw(DomainError(mmax,
@@ -38,8 +33,8 @@ end
 
 @propagate_inbounds function _legendre!(norm, Λ, lmax, mmax, x)
     @boundscheck _chkdomain(lmax, mmax)
-    @boundscheck _chkdomainnorm(norm, lmax, mmax)
     @boundscheck _chkbounds(Λ, lmax, mmax, x)
+    @boundscheck boundscheck_hook(norm, lmax, mmax)
     if ndims(x) > 1
         M = ndims(Λ)
         N = ndims(x)
@@ -195,7 +190,7 @@ Note that in second and third case, the `UnitRange`s must satisify `first(l) == 
 function legendre(norm::AbstractLegendreNorm, l::Integer, m::Integer, x::Number)
     Λ = _similar(x)
     _chkdomain(l, m)
-    _chkdomainnorm(norm, l, m)
+    boundscheck_hook(norm, l, m)
     @inbounds _legendre!(norm, Λ, l, m, x)
     return Λ[]
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -65,3 +65,6 @@ Returns the coefficient ``β_ℓ^m`` for the two-term recursion relation
 where ``β_ℓ^m`` is appropriate for the choice of normalization `N`.
 """
 function Plm_β end
+
+# Hook to allow an AbstractLegendreNorm to participate in bounds checking.
+boundscheck_hook(norm::AbstractLegendreNorm, lmax, mmax) = nothing

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -66,5 +66,18 @@ where ``β_ℓ^m`` is appropriate for the choice of normalization `N`.
 """
 function Plm_β end
 
-# Hook to allow an AbstractLegendreNorm to participate in bounds checking.
+"""
+    boundscheck_hook(norm::AbstractLegendreNorm, lmax, mmax)
+
+A bounds-checking hook executed at the beginning of each [`legendre!`](@ref) call to
+permit a normalization `norm` to validate that the given maximum ``(ℓ,m)`` will be within
+the ability to satisfy. The default case always returns `nothing`. A custom normalization
+should throw an error if `lmax` or `mmax` is out of bounds or return `nothing` otherwise.
+
+For example, the precomputed coefficients of [`LegendreNormCoeff`](@ref) are limited to
+a given domain at time of construction and cannot be used to calculate terms to arbitrary
+orders/degrees.
+"""
+function boundscheck_hook end
+
 boundscheck_hook(norm::AbstractLegendreNorm, lmax, mmax) = nothing

--- a/src/norm_table.jl
+++ b/src/norm_table.jl
@@ -100,3 +100,10 @@ end
 Plm_β(norm::LegendreNormCoeff, ::Type{T}, l::Integer, m::Integer) where T
     return norm.β[l+1,m+1]
 end
+
+function boundscheck_hook(norm::LegendreNormCoeff, lmax, mmax)
+    @noinline _throw(α, lmax, mmax) = throw(BoundsError(α, (lmax+1, mmax+1)))
+    lmax′,mmax′ = size(norm.α)
+    (lmax < lmax′ && mmax < mmax′) || _throw(norm.α, lmax, mmax)
+    nothing
+end

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -21,7 +21,9 @@ Base.size(s::Scalar) = ()
 @propagate_inbounds Base.setindex!(s::Scalar, x) = (s.x = x; s)
 @propagate_inbounds Base.setindex!(s::Scalar, x, ::CartesianIndex{0}) = (s.x = x; s)
 Base.similar(s::Scalar{T}) where {T} = Scalar{T}()
+Base.similar(s::Scalar, ::Type{T}) where {T} = Scalar{T}()
 Base.similar(s::Scalar{T}, ::Tuple{}) where {T} = Scalar{T}()
+Base.similar(s::Scalar, ::Type{T}, ::Tuple{}) where {T} = Scalar{T}()
 
 # Iteration on a scalar
 Base.iterate(s::Scalar) = (s.x, nothing)

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -1,20 +1,18 @@
-import ..LMAX
+import ..LMAX, ..Norms
 
 @testset "Degree/order domain errors" begin
     MMAX = LMAX - 2
     Λ = Matrix{Float64}(undef, LMAX+1, MMAX+1)
-    norms = (LegendreUnitNorm(), LegendreSphereNorm(),
-             LegendreUnitCoeff{Float64}(LMAX, MMAX))
 
-    @testset "ℓ < 0 ($(typeof(N))" for N in norms
+    @testset "ℓ < 0 ($(typeof(N))" for N in Norms
         @test_throws DomainError legendre( N,    -1, 0, 0.5)
         @test_throws DomainError legendre!(N, Λ, -1, 0, 0.5)
     end
-    @testset "ℓ > 0 & m < 0 ($(typeof(N))" for N in norms
+    @testset "ℓ > 0 & m < 0 ($(typeof(N))" for N in Norms
         @test_throws DomainError legendre( N,    LMAX, -1, 0.5)
         @test_throws DomainError legendre!(N, Λ, LMAX, -1, 0.5)
     end
-    @testset "m > ℓ ($(typeof(N))" for N in norms
+    @testset "m > ℓ ($(typeof(N))" for N in Norms
         @test_throws DomainError legendre( N,    LMAX, LMAX+1, 0.5)
         @test_throws DomainError legendre!(N, Λ, LMAX, LMAX+1, 0.5)
     end

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -41,8 +41,6 @@ end
     Λ₄ = Array{Float64}(undef, 2, 2, LMAX+1, LMAX+1)
     Λ₅ = Array{Float64}(undef, 2, 2, 2, LMAX+1, LMAX+1)
     # Insufficient dimensions:
-    @test_throws DimensionMismatch Plm!(Λ₁, LMAX, LMAX, 0.0)
-    @test_throws DimensionMismatch Plm!(Λ₂, LMAX, LMAX, zeros(2))
     @test_throws DimensionMismatch Plm!(Λ₃, LMAX, LMAX, zeros(2,2))
     # Too many dimensions:
     @test_throws DimensionMismatch Plm!(Λ₃, LMAX, LMAX, 0.0)

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -1,6 +1,7 @@
+import ..LMAX
+
 @testset "Degree/order domain errors" begin
-    LMAX = 10
-    MMAX = 2
+    MMAX = LMAX - 2
     Λ = Matrix{Float64}(undef, LMAX+1, MMAX+1)
     norms = (LegendreUnitNorm(), LegendreSphereNorm(),
              LegendreUnitCoeff{Float64}(LMAX, MMAX))
@@ -20,23 +21,13 @@
 end
 
 @testset "Degree/order range errors" begin
-    LMAX = 5
-    ctab = LegendreUnitCoeff{Float64}(LMAX)
     # Throws on invalid l ranges
-    @test_throws ArgumentError Plm.(1:LMAX, 0, 0.5)
-    @test_throws ArgumentError λlm.(1:LMAX, 0, 0.5)
-    @test_throws ArgumentError ctab.(1:LMAX, 0, 0.5)
-    @test_throws ArgumentError legendre.(ctab, 1:LMAX, 0, 0.5)
+    @test_throws ArgumentError legendre.(λlm, 1:LMAX, 0, 0.5)
     # Throws on invalid m ranges
-    @test_throws ArgumentError Plm.(0:LMAX, 1:LMAX, 0.5)
-    @test_throws ArgumentError λlm.(0:LMAX, 1:LMAX, 0.5)
-    @test_throws ArgumentError ctab.(0:LMAX, 1:LMAX, 0.5)
-    @test_throws ArgumentError legendre.(ctab, 0:LMAX, 1:LMAX, 0.5)
+    @test_throws ArgumentError legendre.(λlm, 0:LMAX, 1:LMAX, 0.5)
 end
 
 @testset "Output array bounds checking" begin
-    LMAX = 2
-
     # Scalar argument
     λ  = Vector{Float64}(undef, LMAX)
     Λ₁ = Matrix{Float64}(undef, LMAX, LMAX+1)
@@ -62,9 +53,8 @@ end
 end
 
 @testset "Precompute coefficient lmax/mmax" begin
-    LMAX, MMAX = 2, 0
+    MMAX = 0
     ctab = LegendreUnitCoeff{Float64}(LMAX, MMAX)
     @test_throws BoundsError ctab(LMAX+1, 0, 0.5)
     @test_throws BoundsError ctab(LMAX, MMAX+1, 0.5)
 end
-

--- a/test/implementation.jl
+++ b/test/implementation.jl
@@ -1,4 +1,5 @@
 using Random
+import ..Norms
 
 @testset "Equality of legendre[!]" begin
     LMAX = 10
@@ -40,6 +41,30 @@ end
         x = 2rand() - 1
         @test num_deriv1(l, m, x) ≈ dual_deriv1(l, m, x)
         @test num_deriv1(l, m, x) ≈ dual_deriv1_tab(l, m, x)
+    end
+end
+
+@testset "Return inference ($(typeof(N)) with argument type $T)" for N in Norms, T in NumTypes
+    import ..LMAX
+    Λ₀ = fill(0.0)
+    Λ₁ = zeros(LMAX+1)
+    Λ₂ = zeros(LMAX+1, LMAX+1)
+    # 7 cases in recursion to handle:
+    #   1. Initial condition
+    #   2. Boost along diagonal from (even,even) -> (odd,odd)
+    #      2a. Boost in ℓ from (m,m) -> (m+1, m)
+    #      2b. Boost again in ℓ from (m+1,m) -> (m+2, m)
+    #   3. Repeat (2) but for step along diagonal from (odd,odd) -> (even,even)
+    cases = ((0,0), (1,1), (2,1), (3,1), (2,2), (3,2), (4,2))
+    @testset "(ℓ,m) == ($ℓ, $m)" for (ℓ, m) in cases
+        # Return type matches that of the argument, even though internal calculation
+        # will promote.
+        @test @inferred(legendre(N, ℓ, m, one(T))) isa T
+        # Also must handle single value, all ℓ for fixed m, and all (ℓ,m) up to
+        # (LMAX,LMAX)
+        @test @inferred(legendre!(N, Λ₀, LMAX, LMAX, one(T))) isa typeof(Λ₀)
+        @test @inferred(legendre!(N, Λ₁, LMAX, LMAX, one(T))) isa typeof(Λ₁)
+        @test @inferred(legendre!(N, Λ₂, LMAX, LMAX, one(T))) isa typeof(Λ₂)
     end
 end
 

--- a/test/implementation.jl
+++ b/test/implementation.jl
@@ -92,41 +92,19 @@ end
 end
 
 @testset "Broadcasting arguments" begin
-    ctab = LegendreSphereCoeff{Float64}(LMAX)
     x = 0.5
-
-    # Single (l,m) for single z
-    @test Plm.(LMAX, LMAX, x) == Plm(LMAX, LMAX, x)
-    @test λlm.(LMAX, LMAX, x)  == λlm(LMAX, LMAX, x)
-    @test ctab.(LMAX, LMAX, x) == λlm(LMAX, LMAX, x)
-    @test legendre.(LegendreSphereNorm(), LMAX, LMAX, x) == λlm(LMAX, LMAX, x)
-
     z = range(-1, 1, length=10)
     Λ = zeros(length(z), LMAX + 1, LMAX + 1)
+    λlm!(Λ, LMAX, LMAX, z)
 
+    # Single (l,m) for single z
+    @test λlm.(LMAX, LMAX, x) == λlm(LMAX, LMAX, x)
     # Single (l,m) over multiple z
-    legendre!(LegendreUnitNorm(), Λ, LMAX, LMAX, z)
-    @test Plm.(LMAX, LMAX, z) == Λ[:,LMAX+1,LMAX+1]
-    legendre!(LegendreSphereNorm(), Λ, LMAX, LMAX, z)
-    @test λlm.(LMAX, LMAX, z)  == Λ[:,LMAX+1,LMAX+1]
-    @test ctab.(LMAX, LMAX, z) == Λ[:,LMAX+1,LMAX+1]
-    @test legendre.(LegendreSphereNorm(), LMAX, LMAX, z) == Λ[:,LMAX+1,LMAX+1]
-
+    @test λlm.(LMAX, LMAX, z) == Λ[:,LMAX+1,LMAX+1]
     # All l for fixed m over multiple z
-    legendre!(LegendreUnitNorm(), Λ, LMAX, LMAX, z)
-    @test Plm.(0:LMAX, LMAX, z) == Λ[:,:,LMAX+1]
-    legendre!(LegendreSphereNorm(), Λ, LMAX, LMAX, z)
-    @test λlm.(0:LMAX, LMAX, z)  == Λ[:,:,LMAX+1]
-    @test ctab.(0:LMAX, LMAX, z) == Λ[:,:,LMAX+1]
-    @test legendre.(LegendreSphereNorm(), 0:LMAX, LMAX, z) == Λ[:,:,LMAX+1]
-
+    @test λlm.(0:LMAX, LMAX, z) == Λ[:,:,LMAX+1]
     # All l and m over multiple z
-    legendre!(LegendreUnitNorm(), Λ, LMAX, LMAX, z)
-    @test Plm.(0:LMAX, 0:LMAX, z) == Λ
-    legendre!(LegendreSphereNorm(), Λ, LMAX, LMAX, z)
-    @test λlm.(0:LMAX, 0:LMAX, z)  == Λ
-    @test ctab.(0:LMAX, 0:LMAX, z) == Λ
-    @test legendre.(LegendreSphereNorm(), 0:LMAX, 0:LMAX, z) == Λ
+    @test λlm.(0:LMAX, 0:LMAX, z) == Λ
 
     # Shape-preservation of multi-dimensional arguments
     sz = (5, 10)

--- a/test/implementation.jl
+++ b/test/implementation.jl
@@ -43,6 +43,23 @@ end
     end
 end
 
+@testset "Internal type promotion" begin
+    LMAX = 5
+    # The implementation should promote all internal calculations, so given arguments
+    # 0.5f0 (32-bit) and 0.5e0 (64-bit) which can both be exactly represented, calculate
+    # that the former is calculated at 64-bit precision when the 64-bit output encourages
+    # it.
+    @test λlm!(fill(0.0), LMAX, LMAX, 0.5f0) == λlm!(fill(0.0), LMAX, LMAX, 0.5e0)
+    # Do the same for a normalization which contains its own inherent element type.
+    # Now take advantage of the fact that 0.2 is not exactly representable and have
+    # different approximations at different accuracy to induce numerical differences
+    # based on whether the values have been promoted or not.
+    bigΛ! = LegendreSphereCoeff{BigFloat}(LMAX)
+    λ1 = bigΛ!(fill(0f0), LMAX, LMAX, 0.2f0)
+    λ2 = bigΛ!(fill(big(0f0)), LMAX, LMAX, big(0.2f0))
+    @test λ1[] == Float32(λ2[])
+end
+
 @testset "Broadcasting arguments" begin
     LMAX = 5
     ctab = LegendreSphereCoeff{Float64}(LMAX)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,10 +30,10 @@ end
 
 @testset ExtendedTestSet "Legendre" begin
     @include "norms.jl" "Normalizations"
-    @include "errors.jl" "Error checking"
     @include "coeffs.jl" "Precomputed coefficients"
-    @include "analytic.jl" "Analytic checks"
     @include "implementation.jl" "Implementation details"
+    @include "analytic.jl" "Analytic checks"
+    @include "errors.jl" "Error checking"
     @include "scalar.jl" "Utility: scalar container"
     @include "doctests.jl" "Doctests"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,8 @@ using Test, TestSetExtensions
 using Legendre # For doctests, include Legendre as a binding in Main
 
 include("testsuite.jl")
-using .TestSuite: NumTypes
+using .TestSuite: LMAX, NumTypes
+const Norms = (LegendreUnitNorm(), LegendreUnitCoeff{BigFloat}(LMAX))
 
 function prettytime(t)
     v, u = t < 1e3 ? (t, "ns") :

--- a/test/scalar.jl
+++ b/test/scalar.jl
@@ -19,7 +19,9 @@ s[I] = fill(3)
 @test ndims(s) == 0
 @test length(s) == 1
 @test similar(s) isa Scalar{Float64}
+@test similar(s, Float32) isa Scalar{Float32}
 @test similar(s, size(s)) isa Scalar{Float64}
+@test similar(s, Float32, size(s)) isa Scalar{Float32}
 
 @test [x for x in s] == fill(s[])
 

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -24,6 +24,9 @@ module TestSuite
             @test isfinite(Legendre.Plm_α(norm, Float64, 1, 0))
             @test isfinite(Legendre.Plm_β(norm, Float64, 1, 0))
 
+            # Check that the boundscheck_hook() returns `nothing`
+            @test @inferred(Legendre.boundscheck_hook(norm, 0, 0)) === nothing
+
             # Make sure object calls have not been shadowed
             Λ₁ = zeros(LMAX+1, LMAX+1)
             Λ₂ = zeros(LMAX+1, LMAX+1)

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -6,7 +6,6 @@ module TestSuite
     function runtests(norm)
         @testset "Normalization $(typeof(norm))" begin
             interface(norm)
-            promotion(norm)
         end
     end
 
@@ -32,31 +31,6 @@ module TestSuite
             Λ₂ = zeros(LMAX+1, LMAX+1)
             @test norm(    LMAX, LMAX, 0.5) == legendre( norm,     LMAX, LMAX, 0.5)
             @test norm(Λ₁, LMAX, LMAX, 0.5) == legendre!(norm, Λ₁, LMAX, LMAX, 0.5)
-        end
-    end
-
-    function promotion(norm)
-        Λ₀ = fill(0.0)
-        Λ₁ = zeros(LMAX+1)
-        Λ₂ = zeros(LMAX+1, LMAX+1)
-        @testset "Argument eltype $T" for T in NumTypes
-            # 7 cases in recursion to handle:
-            #   1. Initial condition
-            #   2. Boost along diagonal from (even,even) -> (odd,odd)
-            #      2a. Boost in ℓ from (m,m) -> (m+1, m)
-            #      2b. Boost again in ℓ from (m+1,m) -> (m+2, m)
-            #   3. Repeat (2) but for step along diagonal from (odd,odd) -> (even,even)
-            cases = ((0,0), (1,1), (2,1), (3,1), (2,2), (3,2), (4,2))
-            @testset "(ℓ,m) == ($ℓ, $m)" for (ℓ, m) in cases
-                # Return type matches that of the argument, even though internal calculation
-                # will promote.
-                @test @inferred(legendre(norm, ℓ, m, one(T))) isa T
-                # Also must handle single value, all ℓ for fixed m, and all (ℓ,m) up to
-                # (LMAX,LMAX)
-                @test @inferred(legendre!(norm, Λ₀, LMAX, LMAX, one(T))) isa typeof(Λ₀)
-                @test @inferred(legendre!(norm, Λ₁, LMAX, LMAX, one(T))) isa typeof(Λ₁)
-                @test @inferred(legendre!(norm, Λ₂, LMAX, LMAX, one(T))) isa typeof(Λ₂)
-            end
         end
     end
 end


### PR DESCRIPTION
* Make boundschecking upon the normalization object part of the interface.
  * Documented the interface.
* Fix an error in handling the internal type promotion mechanism.
* Move some tests from part of the interface test suite back into the primary implementation tests.
* Simplified/consolidated various tests.
* Split up the documentation into smaller units.