### PR TITLE
Make math documentation more clear

### DIFF
--- a/docs/src/man/devdocs.md
+++ b/docs/src/man/devdocs.md
@@ -55,15 +55,15 @@ relations given in the [Definitions and Properties](@ref legendre_defn) section.
 For our purposes, they take on the form:
 ```math
 \begin{align}
-    P_{\ell+1}^m(x) &= \alpha_{\ell+1}^m x P_\ell^m(x)
-        - \beta_{\ell+1}^m P_{\ell-1}^m(x)
-        \label{eqn:cus_rr_2term}
-    \\
     P_{m+1}^{m+1}(x) &= \mu_{m+1} \sqrt{1-x^2} P_m^m(x)
         \label{eqn:cus_rr_1term_lm}
     \\
     P_{m+1}^m(x) &= \nu_m x P_m^m(x)
         \label{eqn:cus_rr_1term_l}
+    \\
+    P_{\ell+1}^m(x) &= \alpha_{\ell+1}^m x P_\ell^m(x)
+        - \beta_{\ell+1}^m P_{\ell-1}^m(x)
+        \label{eqn:cus_rr_2term}
 \end{align}
 ```
 The normalization is encoded in the coefficients ``α_ℓ^m``, ``β_ℓ^m``, ``μ_m``, and
@@ -71,10 +71,10 @@ The normalization is encoded in the coefficients ``α_ℓ^m``, ``β_ℓ^m``, ``�
 For the standard (unity) normalization, these take on the values
 ```math
 \begin{align}
-    α_ℓ^m &= \frac{2ℓ - 1}{ℓ - m} \\
-    β_ℓ^m &= \frac{ℓ + m - 1}{ℓ - m} \\
     μ_m &= 2ℓ - 1 \\
-    ν_m &= 2ℓ + 1
+    ν_m &= 2ℓ + 1 \\
+    α_ℓ^m &= \frac{2ℓ - 1}{ℓ - m} \\
+    β_ℓ^m &= \frac{ℓ + m - 1}{ℓ - m}
 \end{align}
 ```
 by simply identifying the coefficients from Eqns.
@@ -114,10 +114,10 @@ they are the cofficients appropriate for generating ``λ_{ℓ+1}^m(x)``.
 Doing so with the other two recurrence relation equations, we obtain:
 ```math
 \begin{align}
-    α_ℓ^m &= \sqrt{\frac{2ℓ+1}{2ℓ-3} \frac{4(ℓ-1)^2 - 1}{ℓ^2 - m^2}} \\
-    β_ℓ^m &= \sqrt{\frac{2ℓ+1}{2ℓ-3} \frac{(ℓ-1)^2 - m^2}{ℓ^2 - m^2}} \\
     μ_m &= \sqrt{1 + \frac{1}{2m}} \\
-    ν_m &= \sqrt{2m + 3}
+    ν_m &= \sqrt{2m + 3} \\
+    α_ℓ^m &= \sqrt{\frac{2ℓ+1}{2ℓ-3} \frac{4(ℓ-1)^2 - 1}{ℓ^2 - m^2}} \\
+    β_ℓ^m &= \sqrt{\frac{2ℓ+1}{2ℓ-3} \frac{(ℓ-1)^2 - m^2}{ℓ^2 - m^2}}
 \end{align}
 ```
 The final math required is to define the initial condition ``λ_0^0(x)``.

--- a/docs/src/man/devdocs.md
+++ b/docs/src/man/devdocs.md
@@ -27,10 +27,10 @@ implement.
 |:--------------------------------------- |:----------------------------------------------------------------------------------------------- |
 | [`Legendre.AbstractLegendreNorm`](@ref) | Supertype of normalization trait types                                                          |
 | [`Legendre.Plm_00()`](@ref)             | Value of ``N_0^0 P_0^0(x)`` for the given normalization                                         |
-| [`Legendre.Plm_μ()`](@ref)              | Coefficient ``μ_ℓ`` for the 1-term r.r. boosting ``ℓ → ℓ+1`` and ``m → m+1`` where ``m = \ell`` |
-| [`Legendre.Plm_ν()`](@ref)              | Coefficient ``ν_ℓ`` for the 1-term r.r. boosting ``ℓ → ℓ+1``                                    |
-| [`Legendre.Plm_α()`](@ref)              | Coefficient ``α_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ,m)`` term                          |
-| [`Legendre.Plm_β()`](@ref)              | Coefficient ``β_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ-1,m)`` term                        |
+| [`Legendre.Plm_μ()`](@ref)              | Coefficient ``μ_ℓ`` for the 1-term r.r. boosting ``ℓ-1 → ℓ`` and ``m-1 → m`` where ``m = \ell`` |
+| [`Legendre.Plm_ν()`](@ref)              | Coefficient ``ν_ℓ`` for the 1-term r.r. boosting ``ℓ-1 → ℓ``                                    |
+| [`Legendre.Plm_α()`](@ref)              | Coefficient ``α_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ-1,m)`` term                          |
+| [`Legendre.Plm_β()`](@ref)              | Coefficient ``β_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ-2,m)`` term                        |
 
 | Optional interfaces                 | Brief description                      |
 |:----------------------------------- |:-------------------------------------- |
@@ -50,19 +50,24 @@ spherical harmonic normalization baked in.
 \end{align}
 ```
 
+[^1]:
+    Note that here we have shifted the indices by 1 compared to the definitions
+    in the introduction such that the left-hand side is always written in terms
+    of degree ``ℓ`` rather than ``ℓ+1``.
+
 Baking in the normalization happens by changing the coefficients in the recursion
-relations given in the [Definitions and Properties](@ref legendre_defn) section.
+relations given in the [Definitions and Properties](@ref legendre_defn) section[^1].
 For our purposes, they take on the form:
 ```math
 \begin{align}
-    P_{\ell+1}^{\ell+1}(x) &= \mu_{\ell+1} \sqrt{1-x^2} P_\ell^\ell(x)
+    P_ℓ^ℓ(x) &= \mu_ℓ \sqrt{1-x^2} P_{ℓ-1}^{ℓ-1}(x)
         \label{eqn:cus_rr_1term_lm}
     \\
-    P_{\ell+1}^\ell(x) &= \nu_{\ell+1} x P_\ell^\ell(x)
+    P_ℓ^{ℓ-1}(x) &= \nu_ℓ x P_{ℓ-1}^{ℓ-1}(x)
         \label{eqn:cus_rr_1term_l}
     \\
-    P_{\ell+1}^m(x) &= \alpha_{\ell+1}^m x P_\ell^m(x)
-        - \beta_{\ell+1}^m P_{\ell-1}^m(x)
+    P_ℓ^m(x) &= \alpha_ℓ^m x P_{ℓ-1}^m(x)
+        - \beta_ℓ^m P_{ℓ-2}^m(x)
         \label{eqn:cus_rr_2term}
 \end{align}
 ```
@@ -80,37 +85,38 @@ For the standard (unity) normalization, these take on the values
 by simply identifying the coefficients from Eqns.
 ``\ref{eqn:cus_rr_2term}``–``\ref{eqn:cus_rr_1term_l}`` on each of the ``P_ℓ^m(x)`` terms
 on the right hand side.
+
 For other normalizations, we multiply through by the normalization factor
 appropriate for the left-hand side of the equations, rearrange terms to
 correctly normalize the terms on the right, and identify the coefficients left
 over.
 For example, ``α_ℓ^m`` and ``β_ℓ^m`` for ``λ_ℓ^m(x)`` are determined by starting with
-Eq. ``\ref{eqn:cus_rr_2term}`` and multiply through by ``N_{ℓ+1}^m``.
-The left-hand side by definition is ``λ_{ℓ+1}^m``, leaving us with
+Eq. ``\ref{eqn:cus_rr_2term}`` and multiply through by ``N_ℓ^m``.
+The left-hand side by definition is ``λ_ℓ^m``, leaving us with
 ```math
 \begin{align}
     \begin{split}
-        λ_{ℓ+1}^m &= \frac{2ℓ + 1}{ℓ - m + 1} x
-            \sqrt{\frac{2ℓ+3}{4π} \frac{(ℓ-m+1)!}{(ℓ+m+1)!}} P_ℓ^m(x) -
+        λ_ℓ^m &= \frac{2ℓ-1}{ℓ-m} x
+            \sqrt{\frac{2ℓ+1}{4π} \frac{(ℓ-m)!}{(ℓ+m)!}} P_{ℓ-1}^m(x) -
             \\
-            &\quad\quad \frac{ℓ+m}{ℓ-m+1} \sqrt{\frac{2ℓ+3}{4π}
-            \frac{(ℓ-m+1)!}{(ℓ+m+1)!}} P_{ℓ-1}^m(x)
+            &\quad\quad \frac{ℓ+m-1}{ℓ-m} \sqrt{\frac{2ℓ+1}{4π}
+            \frac{(ℓ-m)!}{(ℓ+m)!}} P_{ℓ-2}^m(x)
     \end{split}
 \end{align}
 ```
 Through judicious use of algebra, the terms on the right-hand side can be manipulated
-to gather terms of the form ``N_ℓ^m P_ℓ^m(x)`` and ``N_{ℓ-1}^m P_{ℓ-1}^m(x)``, leaving us
-with
+to gather terms of the form ``N_{ℓ-1}^m P_{ℓ-1}^m(x)`` and
+``N_{ℓ-2}^m P_{ℓ-2}^m(x)``, leaving us with
 ```math
 \begin{align}
-    λ_{ℓ+1}^m &= \sqrt{\frac{2ℓ+3}{2ℓ-1} \frac{4ℓ^2 - 1}{(ℓ+1)^2 - m^2}} x
-        λ_ℓ^m(x) -
-        \sqrt{\frac{2ℓ+3}{2ℓ-1} \frac{ℓ^2 - m^2}{(ℓ+1)^2 - m^2}}
-        λ_{ℓ-1}^m(x)
+    λ_ℓ^m &= \sqrt{\frac{2ℓ+1}{2ℓ-3} \frac{4(ℓ-1)^2 - 1}{ℓ^2 - m^2}} x
+        λ_{ℓ-1}^m(x) -
+        \sqrt{\frac{2ℓ+1}{2ℓ-3} \frac{(ℓ-1)^2 - m^2}{ℓ^2 - m^2}}
+        λ_{ℓ-2}^m(x)
 \end{align}
 ```
-We identify each of the two square root terms as ``α_{ℓ+1}^m`` and ``β_{ℓ+1}^m`` since
-they are the cofficients appropriate for generating ``λ_{ℓ+1}^m(x)``.
+We identify each of the two square root terms as ``α_ℓ^m`` and ``β_ℓ^m`` since
+they are the cofficients appropriate for generating ``λ_ℓ^m(x)``.
 Doing so with the other two recurrence relation equations, we obtain:
 ```math
 \begin{align}

--- a/docs/src/man/devdocs.md
+++ b/docs/src/man/devdocs.md
@@ -23,14 +23,14 @@ implement.
 
 ### Normalization Interface
 
-| Interfaces to extend/implement          | Brief description                                                            |
-|:--------------------------------------- |:---------------------------------------------------------------------------- |
-| [`Legendre.AbstractLegendreNorm`](@ref) | Supertype of normalization trait types                                       |
-| [`Legendre.Plm_00()`](@ref)             | Value of ``N_0^0 P_0^0(x)`` for the given normalization                      |
-| [`Legendre.Plm_μ()`](@ref)              | Coefficient ``μ_m`` for the 1-term r.r. boosting ``ℓ → ℓ+1`` and ``m → m+1`` |
-| [`Legendre.Plm_ν()`](@ref)              | Coefficient ``ν_m`` for the 1-term r.r. boosting ``ℓ → ℓ+1``                 |
-| [`Legendre.Plm_α()`](@ref)              | Coefficient ``α_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ,m)`` term       |
-| [`Legendre.Plm_β()`](@ref)              | Coefficient ``β_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ-1,m)`` term     |
+| Interfaces to extend/implement          | Brief description                                                                               |
+|:--------------------------------------- |:----------------------------------------------------------------------------------------------- |
+| [`Legendre.AbstractLegendreNorm`](@ref) | Supertype of normalization trait types                                                          |
+| [`Legendre.Plm_00()`](@ref)             | Value of ``N_0^0 P_0^0(x)`` for the given normalization                                         |
+| [`Legendre.Plm_μ()`](@ref)              | Coefficient ``μ_ℓ`` for the 1-term r.r. boosting ``ℓ → ℓ+1`` and ``m → m+1`` where ``m = \ell`` |
+| [`Legendre.Plm_ν()`](@ref)              | Coefficient ``ν_ℓ`` for the 1-term r.r. boosting ``ℓ → ℓ+1``                                    |
+| [`Legendre.Plm_α()`](@ref)              | Coefficient ``α_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ,m)`` term                          |
+| [`Legendre.Plm_β()`](@ref)              | Coefficient ``β_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ-1,m)`` term                        |
 
 | Optional interfaces                 | Brief description                      |
 |:----------------------------------- |:-------------------------------------- |
@@ -55,10 +55,10 @@ relations given in the [Definitions and Properties](@ref legendre_defn) section.
 For our purposes, they take on the form:
 ```math
 \begin{align}
-    P_{m+1}^{m+1}(x) &= \mu_{m+1} \sqrt{1-x^2} P_m^m(x)
+    P_{\ell+1}^{\ell+1}(x) &= \mu_{\ell+1} \sqrt{1-x^2} P_\ell^\ell(x)
         \label{eqn:cus_rr_1term_lm}
     \\
-    P_{m+1}^m(x) &= \nu_m x P_m^m(x)
+    P_{\ell+1}^\ell(x) &= \nu_{\ell+1} x P_\ell^\ell(x)
         \label{eqn:cus_rr_1term_l}
     \\
     P_{\ell+1}^m(x) &= \alpha_{\ell+1}^m x P_\ell^m(x)
@@ -66,13 +66,13 @@ For our purposes, they take on the form:
         \label{eqn:cus_rr_2term}
 \end{align}
 ```
-The normalization is encoded in the coefficients ``α_ℓ^m``, ``β_ℓ^m``, ``μ_m``, and
-``ν_m``.
+The normalization is encoded in the coefficients ``μ_ℓ``, ``ν_ℓ``, ``α_ℓ^m``,
+``β_ℓ^m``.
 For the standard (unity) normalization, these take on the values
 ```math
 \begin{align}
-    μ_m &= 2ℓ - 1 \\
-    ν_m &= 2ℓ + 1 \\
+    μ_ℓ &= 2ℓ - 1 \\
+    ν_ℓ &= 2ℓ - 1 \\
     α_ℓ^m &= \frac{2ℓ - 1}{ℓ - m} \\
     β_ℓ^m &= \frac{ℓ + m - 1}{ℓ - m}
 \end{align}
@@ -114,8 +114,8 @@ they are the cofficients appropriate for generating ``λ_{ℓ+1}^m(x)``.
 Doing so with the other two recurrence relation equations, we obtain:
 ```math
 \begin{align}
-    μ_m &= \sqrt{1 + \frac{1}{2m}} \\
-    ν_m &= \sqrt{2m + 3} \\
+    μ_ℓ &= \sqrt{1 + \frac{1}{2ℓ}} \\
+    ν_ℓ &= \sqrt{2ℓ + 1} \\
     α_ℓ^m &= \sqrt{\frac{2ℓ+1}{2ℓ-3} \frac{4(ℓ-1)^2 - 1}{ℓ^2 - m^2}} \\
     β_ℓ^m &= \sqrt{\frac{2ℓ+1}{2ℓ-3} \frac{(ℓ-1)^2 - m^2}{ℓ^2 - m^2}}
 \end{align}
@@ -165,10 +165,10 @@ julia> function Plm_β(::λNorm, T::Type, l::Integer, m::Integer)
        end
 Plm_β (generic function with 4 methods)
 
-julia> Plm_μ(::λNorm, T::Type, m::Integer) = sqrt(1 + 1 / 2m)
+julia> Plm_μ(::λNorm, T::Type, l::Integer) = sqrt(1 + 1 / 2l)
 Plm_μ (generic function with 4 methods)
 
-julia> Plm_ν(::λNorm, T::Type, m::Integer) = sqrt(3 + 2m)
+julia> Plm_ν(::λNorm, T::Type, l::Integer) = sqrt(1 + 2l)
 Plm_ν (generic function with 4 methods)
 ```
 

--- a/docs/src/man/intro.md
+++ b/docs/src/man/intro.md
@@ -54,14 +54,14 @@ mechanics and obeys the following properties:
   following recursion relations (given the initial condition ``P_0^0(x)``):
   ```math
   \begin{align}
-      (ℓ - m + 1)P_{ℓ+1}^m(x) &= (2ℓ+1)xP_ℓ^m(x) - (ℓ+m)P_{ℓ-1}^m(x)
-      \label{eqn:std_rr_2term}
-      \\
       P_{ℓ+1}^{ℓ+1}(x) &= -(2ℓ+1)\sqrt{1-x^2} P_ℓ^ℓ(x)
       \label{eqn:std_rr_1term_lm}
       \\
       P_{ℓ+1}^ℓ(x) &= x(2ℓ+1)P_ℓ^ℓ(x)
       \label{eqn:std_rr_1term_l}
+      \\
+      (ℓ - m + 1)P_{ℓ+1}^m(x) &= (2ℓ+1)xP_ℓ^m(x) - (ℓ+m)P_{ℓ-1}^m(x)
+      \label{eqn:std_rr_2term}
   \end{align}
   ```
 

--- a/docs/src/man/usage.md
+++ b/docs/src/man/usage.md
@@ -26,7 +26,7 @@ compute the spherical harmonics ``Y_{ℓm}(θ,ϕ)``:
 ```math
 \begin{align}
     \begin{aligned}
-    Y_{ℓm}(θ,ϕ) &≡ (-1)^m N_ℓ^m P_ℓ^m(\cos θ) e^{imϕ} \\
+    Y_{ℓm}(θ,ϕ) &≡ N_ℓ^m P_ℓ^m(\cos θ) e^{imϕ} \\
     &\text{where } N_ℓ^m ≡ \sqrt{\frac{2ℓ+1}{4π} \frac{(ℓ-m)!}{(ℓ+m)!}}
     \end{aligned}
 \end{align}
@@ -74,7 +74,7 @@ defined as
 ```math
 \begin{align}
     \begin{aligned}
-    Y_{ℓm}(θ,ϕ) &= (-1)^m λ_ℓ^m(\cos θ) e^{imϕ} \\
+    Y_{ℓm}(θ,ϕ) &= λ_ℓ^m(\cos θ) e^{imϕ} \\
     & \text{where } λ_ℓ^m(x) ≡ N_ℓ^m P_ℓ^m(x)
     \end{aligned}
 \end{align}

--- a/src/calculation.jl
+++ b/src/calculation.jl
@@ -92,7 +92,7 @@ end
         end
         if N == 2 || m == mmax
             # 1-term recurrence relation taking (m,m) -> (m,m+1)
-            ν = Plm_ν(norm, T, m)
+            ν = Plm_ν(norm, T, m+1)
             @. pl   = pm
             @. plp1 = ν * z * pl
             for l in m+1:lmax
@@ -134,7 +134,7 @@ end
         end
         if N == 2 || m+1 == mmax
             # 1-term recurrence relation taking (m+1,m+1) -> (m+1,m+2)
-            ν = Plm_ν(norm, T, m+1)
+            ν = Plm_ν(norm, T, m+2)
             @. pl   = pmp1
             @. plp1 = ν * z * pl
             for l in m+2:lmax

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -27,7 +27,7 @@ function Plm_00 end
 
 Returns the coefficient ``μ_ℓ`` for the single-term recursion relation
 ```math
-    P_{ℓ+1}^{ℓ+1}(x) = -μ_{ℓ+1} \\sqrt{1-x^2} P_ℓ^ℓ(x)
+    P_ℓ^ℓ(x) = -μ_ℓ \\sqrt{1-x^2} P_{ℓ-1}^{ℓ-1}(x)
 ```
 where ``μ_ℓ`` is appropriate for the choice of normalization `N`.
 """
@@ -38,7 +38,7 @@ function Plm_μ end
 
 Returns the coefficient ``ν_ℓ`` for the single-term recursion relation
 ```math
-    P_{ℓ+1}^ℓ(x) = ν_{ℓ+1} x P_ℓ^ℓ(x)
+    P_ℓ^{ℓ-1}(x) = ν_ℓ x P_{ℓ-1}^{ℓ-1}(x)
 ```
 where ``ν_ℓ`` is appropriate for the choice of normalization `N`.
 """
@@ -49,7 +49,7 @@ function Plm_ν end
 
 Returns the coefficient ``α_ℓ^m`` for the two-term recursion relation
 ```math
-    P_{ℓ+1}^{m}(x) = α_{ℓ+1}^m x P_ℓ^m(x) - β_{ℓ+1}^m P_{ℓ-1}^m(x)
+    P_ℓ^m(x) = α_ℓ^m x P_{ℓ-1}^m(x) - β_ℓ^m P_{ℓ-2}^m(x)
 ```
 where ``α_ℓ^m`` is appropriate for the choice of normalization `N`.
 """
@@ -60,7 +60,7 @@ function Plm_α end
 
 Returns the coefficient ``β_ℓ^m`` for the two-term recursion relation
 ```math
-    P_{ℓ+1}^{m}(x) = α_{ℓ+1}^m x P_ℓ^m(x) - β_{ℓ+1}^m P_{ℓ-1}^m(x)
+    P_ℓ^m(x) = α_ℓ^m x P_{ℓ-1}^m(x) - β_ℓ^m P_{ℓ-2}^m(x)
 ```
 where ``β_ℓ^m`` is appropriate for the choice of normalization `N`.
 """

--- a/src/norm_sphere.jl
+++ b/src/norm_sphere.jl
@@ -17,13 +17,13 @@ Plm_00(::LegendreSphereNorm, ::Type{T}) where T
 end
 
 @inline function
-Plm_μ(::LegendreSphereNorm, ::Type{T}, m::Integer) where T
-    return sqrt(one(T) + inv(convert(T, 2m)))
+Plm_μ(::LegendreSphereNorm, ::Type{T}, l::Integer) where T
+    return sqrt(one(T) + inv(convert(T, 2l)))
 end
 
 @inline function
-Plm_ν(::LegendreSphereNorm, ::Type{T}, m::Integer) where T
-    return sqrt(convert(T, 2m + 3))
+Plm_ν(::LegendreSphereNorm, ::Type{T}, l::Integer) where T
+    return sqrt(convert(T, 2l + 1))
 end
 
 @inline function

--- a/src/norm_table.jl
+++ b/src/norm_table.jl
@@ -33,7 +33,8 @@ struct LegendreNormCoeff{N<:AbstractLegendreNorm,T<:Real} <: AbstractLegendreNor
 
         @inbounds for m in 0:mmax
             μ[m+1] = m == 0 ? zero(T) : Plm_μ(N(), T, m)
-            ν[m+1] = Plm_ν(N(), T, m)
+            # N.B.: Need access to mmax+1 but will never use m==0 term, so offset storage
+            ν[m+1] = Plm_ν(N(), T, m+1)
 
             for l in (m+1):lmax
                 α[l+1,m+1] = Plm_α(N(), T, l, m)
@@ -82,13 +83,14 @@ Plm_00(::LegendreNormCoeff{N}, ::Type{T}) where {N<:AbstractLegendreNorm, T}
 end
 
 @propagate_inbounds function
-Plm_μ(norm::LegendreNormCoeff, ::Type{T}, m::Integer) where T
-    return norm.μ[m+1]
+Plm_μ(norm::LegendreNormCoeff, ::Type{T}, l::Integer) where T
+    return norm.μ[l+1]
 end
 
 @propagate_inbounds function
-Plm_ν(norm::LegendreNormCoeff, ::Type{T}, m::Integer) where T
-    return norm.ν[m+1]
+Plm_ν(norm::LegendreNormCoeff, ::Type{T}, l::Integer) where T
+    # N.B.: Storage is offset by 1 compared to other arrays. See constructor.
+    return norm.ν[l]
 end
 
 @propagate_inbounds function

--- a/src/norm_unit.jl
+++ b/src/norm_unit.jl
@@ -13,13 +13,13 @@ Plm_00(::LegendreUnitNorm, ::Type{T}) where T
 end
 
 @inline function
-Plm_μ(::LegendreUnitNorm, ::Type{T}, m::Integer) where T
-    return convert(T, 2m - 1)
+Plm_μ(::LegendreUnitNorm, ::Type{T}, l::Integer) where T
+    return convert(T, 2l - 1)
 end
 
 @inline function
-Plm_ν(::LegendreUnitNorm, ::Type{T}, m::Integer) where T
-    return convert(T, 2m + 1)
+Plm_ν(::LegendreUnitNorm, ::Type{T}, l::Integer) where T
+    return convert(T, 2l - 1)
 end
 
 @inline function


### PR DESCRIPTION
...and update the code to match.

The changes primarily revolve around two changes in notation/convention:
1. Write all functions in terms of their degree ℓ. Previously, the two 1-term recurrence relations were written in terms of the order m.
2. Reindex the documentation so that the recurrence relations are defined in terms of degree ℓ instead of ℓ+1 on the left-hand side.

This is another breaking change since the implicit definition of the `Plm_ν` function changed so that values should be calculated based on ℓ instead of m.