### PR TITLE
Rewrite core computation to match docs and for better performance

### DIFF
--- a/src/calculation.jl
+++ b/src/calculation.jl
@@ -1,4 +1,4 @@
-import Base: checkindex, checkbounds_indices, OneTo
+import Base: checkindex, checkbounds_indices, OneTo, Slice
 
 function _chkdomain(lmax, mmax)
     @noinline _chkdomain_throw_lmax(l) = throw(DomainError(l, "degree lmax must be non-negative"))
@@ -82,7 +82,7 @@ end
 
     M = ndims(x)
     N = ndims(Λ) - M
-    I = CartesianIndices(axes(x))
+    I = CartesianIndices(map(Slice, axes(x)))
     mmax′ = mmax - mod(unsigned(mmax), 2)
 
     local μ₁, μ₂

--- a/src/calculation.jl
+++ b/src/calculation.jl
@@ -92,41 +92,42 @@ end
         pmp1 = pmp2 # name alias
 
         # First iteration: takes even m to m+1
+        m′ = m
         if N == 2
-            Λ[I,m+1,m+1] = pm
-        elseif N == 1 && m == mmax
-            Λ[I,m+1] = pm
-        elseif N == 0 && lmax == m
+            Λ[I,m′+1,m′+1] = pm
+        elseif N == 1 && m′ == mmax
+            Λ[I,m′+1] = pm
+        elseif N == 0
             Λ[I] = pm
-            return Λ
         end
-        if N == 2 || m == mmax
-            # 1-term recurrence relation taking (m,m) -> (m,m+1)
-            ν = Plm_ν(norm, T, m+1)
+
+        if N == 2 || m′ == mmax
+            # 1-term recurrence relation taking (l-1,l-1) -> (l,l-1) where l == m′ == m
+            l = m′ + 1
+            ν = Plm_ν(norm, T, l)
             @. pl   = pm
             @. plp1 = ν * z * pl
-            for l in m+1:lmax
+            for l in m′+1:lmax
                 plm1, pl, plp1 = pl, plp1, plm1
                 if l < lmax
                     # 2-term recurrence relation taking (l,m) -> (l+1, m)
-                    α = Plm_α(norm, T, l+1, m)
-                    β = Plm_β(norm, T, l+1, m)
+                    α = Plm_α(norm, T, l+1, m′)
+                    β = Plm_β(norm, T, l+1, m′)
                     @. plp1 = α * z * pl - β * plm1
                 end
 
                 if N == 2
-                    Λ[I,l+1,m+1] = pl
+                    Λ[I,l+1,m′+1] = pl
                 elseif N == 1
                     Λ[I,l+1] = pl
                 elseif N == 0 && l == lmax
                     Λ[I] = pl
-                    return
                 end
             end
         end
-        if m < mmax
+        if m′ < mmax
             # 1-term recurrence relation taking (m,m) -> (m+1,m+1)
-            μ₁ = Plm_μ(norm, T, m+1)
+            μ₁ = Plm_μ(norm, T, m′+1)
             @. pmp1 = -μ₁ * y¹ * pm
         end
 
@@ -134,41 +135,42 @@ end
 
         # Second iteration: takes even m to m+2
 
+        m′ = m + 1
         if N == 2
-            Λ[I,m+2,m+2] = pmp1
-        elseif N == 1 && m+1 == mmax
-            Λ[I,m+2] = pmp1
-        elseif N == 0 && m+1 == lmax
+            Λ[I,m′+1,m′+1] = pmp1
+        elseif N == 1 && m′ == mmax
+            Λ[I,m′+1] = pmp1
+        elseif N == 0
             Λ[I] = pmp1
-            return Λ
         end
-        if N == 2 || m+1 == mmax
-            # 1-term recurrence relation taking (m+1,m+1) -> (m+1,m+2)
-            ν = Plm_ν(norm, T, m+2)
+
+        if N == 2 || m′ == mmax
+            # 1-term recurrence relation taking (l-1,l-1) -> (l,l-1) where l == m′ == m + 1
+            l = m′ + 1
+            ν = Plm_ν(norm, T, l)
             @. pl   = pmp1
             @. plp1 = ν * z * pl
-            for l in m+2:lmax
+            for l in m′+1:lmax
                 plm1, pl, plp1 = pl, plp1, plm1
                 if l < lmax
                     # 2-term recurrence relation taking (l,m+1) -> (l+1, m+1)
-                    α = Plm_α(norm, T, l+1, m+1)
-                    β = Plm_β(norm, T, l+1, m+1)
+                    α = Plm_α(norm, T, l+1, m′)
+                    β = Plm_β(norm, T, l+1, m′)
                     @. plp1 = α * z * pl - β * plm1
                 end
 
                 if N == 2
-                    Λ[I,l+1,m+2] = pl
+                    Λ[I,l+1,m′+1] = pl
                 elseif N == 1
                     Λ[I,l+1] = pl
-                elseif N == 0 && l == lmax
+                elseif N == 0
                     Λ[I] = pl
-                    return
                 end
             end
         end
-        if m+1 < mmax
+        if m′ < mmax
             # 1-term recurrence relation applied twice taking (m,m) -> (m+2,m+2)
-            μ₂ = Plm_μ(norm, T, m+2)
+            μ₂ = Plm_μ(norm, T, m′+1)
             @. pmp2 = μ₁ * μ₂ * y² * pm
         end
     end


### PR DESCRIPTION
This originally started as a couple of simple changes to realign the code with the mathematical documentation, but as I explored the typed/LLVM IR, I found various ways to improve it for higher performance.

The major improvements are:
1. Deduplicate the loop over `m`s so that the loop over `l` isn't written out twice. This vastly decreases the generated code length.
2. Switch from broadcast operations to explicit loops. We know everything about the shape of all the interacting arrays, so the overhead in broadcasting's shape checks can be eliminated, giving large speed increases.

Using the new benchmark script from (#11), the comparison to master gives:
```
"LegendreUnitNorm" => 12-element BenchmarkTools.BenchmarkGroup:
        tags: []
        "(\"outdim0\", \"indim0\")" => TrialJudgement(-20.61% => improvement)
        "(\"outdim0\", \"indim1\")" => TrialJudgement(-51.90% => improvement)
        "(\"outdim0\", \"indim2\")" => TrialJudgement(-52.13% => improvement)
        "(\"outdim0\", \"inscalar\")" => TrialJudgement(-4.69% => invariant)
        "(\"outdim1\", \"indim0\")" => TrialJudgement(-54.08% => improvement)
        "(\"outdim1\", \"indim1\")" => TrialJudgement(-67.33% => improvement)
        "(\"outdim1\", \"indim2\")" => TrialJudgement(-67.66% => improvement)
        "(\"outdim1\", \"inscalar\")" => TrialJudgement(-53.54% => improvement)
        "(\"outdim2\", \"indim0\")" => TrialJudgement(-65.21% => improvement)
        "(\"outdim2\", \"indim1\")" => TrialJudgement(-50.80% => improvement)
        "(\"outdim2\", \"indim2\")" => TrialJudgement(-49.74% => improvement)
        "(\"outdim2\", \"inscalar\")" => TrialJudgement(-63.43% => improvement)
"LegendreNormCoeff{LegendreSphereNorm,Float64}" => 12-element BenchmarkTools.BenchmarkGroup:
        tags: []
        "(\"outdim0\", \"indim0\")" => TrialJudgement(-24.83% => improvement)
        "(\"outdim0\", \"indim1\")" => TrialJudgement(-54.69% => improvement)
        "(\"outdim0\", \"indim2\")" => TrialJudgement(-53.74% => improvement)
        "(\"outdim0\", \"inscalar\")" => TrialJudgement(-1.40% => invariant)
        "(\"outdim1\", \"indim0\")" => TrialJudgement(-55.08% => improvement)
        "(\"outdim1\", \"indim1\")" => TrialJudgement(-67.62% => improvement)
        "(\"outdim1\", \"indim2\")" => TrialJudgement(-67.17% => improvement)
        "(\"outdim1\", \"inscalar\")" => TrialJudgement(-54.04% => improvement)
        "(\"outdim2\", \"indim0\")" => TrialJudgement(-64.09% => improvement)
        "(\"outdim2\", \"indim1\")" => TrialJudgement(-49.34% => improvement)
        "(\"outdim2\", \"indim2\")" => TrialJudgement(-50.86% => improvement)
        "(\"outdim2\", \"inscalar\")" => TrialJudgement(-66.42% => improvement)
"LegendreSphereNorm" => 12-element BenchmarkTools.BenchmarkGroup:
        tags: []
        "(\"outdim0\", \"indim0\")" => TrialJudgement(-17.59% => improvement)
        "(\"outdim0\", \"indim1\")" => TrialJudgement(-54.17% => improvement)
        "(\"outdim0\", \"indim2\")" => TrialJudgement(-50.57% => improvement)
        "(\"outdim0\", \"inscalar\")" => TrialJudgement(-0.29% => invariant)
        "(\"outdim1\", \"indim0\")" => TrialJudgement(-53.14% => improvement)
        "(\"outdim1\", \"indim1\")" => TrialJudgement(-65.32% => improvement)
        "(\"outdim1\", \"indim2\")" => TrialJudgement(-65.75% => improvement)
        "(\"outdim1\", \"inscalar\")" => TrialJudgement(-48.89% => improvement)
        "(\"outdim2\", \"indim0\")" => TrialJudgement(-60.70% => improvement)
        "(\"outdim2\", \"indim1\")" => TrialJudgement(-52.72% => improvement)
        "(\"outdim2\", \"indim2\")" => TrialJudgement(-52.26% => improvement)
        "(\"outdim2\", \"inscalar\")" => TrialJudgement(-62.06% => improvement)
"LegendreNormCoeff{LegendreUnitNorm,Float64}" => 12-element BenchmarkTools.BenchmarkGroup:
        tags: []
        "(\"outdim0\", \"indim0\")" => TrialJudgement(-25.32% => improvement)
        "(\"outdim0\", \"indim1\")" => TrialJudgement(-52.12% => improvement)
        "(\"outdim0\", \"indim2\")" => TrialJudgement(-51.25% => improvement)
        "(\"outdim0\", \"inscalar\")" => TrialJudgement(-1.45% => invariant)
        "(\"outdim1\", \"indim0\")" => TrialJudgement(-54.67% => improvement)
        "(\"outdim1\", \"indim1\")" => TrialJudgement(-66.70% => improvement)
        "(\"outdim1\", \"indim2\")" => TrialJudgement(-66.90% => improvement)
        "(\"outdim1\", \"inscalar\")" => TrialJudgement(-54.17% => improvement)
        "(\"outdim2\", \"indim0\")" => TrialJudgement(-63.76% => improvement)
        "(\"outdim2\", \"indim1\")" => TrialJudgement(-49.75% => improvement)
        "(\"outdim2\", \"indim2\")" => TrialJudgement(-50.63% => improvement)
        "(\"outdim2\", \"inscalar\")" => TrialJudgement(-72.23% => improvement)
```

Every case improves in performance (except the scalar-input to scalar-output case) by roughly 2–4×.