### PR TITLE
Update CI for v1.5 and limit code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@
 language: julia
 os:
   - linux
-julia:
-  - 1.5
-  - 1.4
-  - 1.2
-  - nightly
 branches:
   only:
     - master
@@ -21,9 +16,11 @@ jobs:
   fast_finish: true
 
   include:
-
-    - julia: # defaults to first in list above
+    - julia: nightly
+    - julia: 1.5
       codecov: true
+    - julia: 1.4
+    - julia: 1.2
 
     - stage: Documentation
       julia: 1.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,15 @@ language: julia
 os:
   - linux
 julia:
-  - 1.2
-  - 1.3
+  - 1.5
   - 1.4
+  - 1.2
   - nightly
 branches:
   only:
     - master
     - /^v[0-9]+\.[0-9]+\.[0-9]+$/ # version tags for Documenter.jl
     - /^release-.*$/
-codecov: true
 notifications:
   email: false
 
@@ -20,7 +19,12 @@ jobs:
   allow_failures:
     - julia: nightly
   fast_finish: true
+
   include:
+
+    - julia: # defaults to first in list above
+      codecov: true
+
     - stage: Documentation
       julia: 1.2
       os: linux


### PR DESCRIPTION
1. Update to start including Julia v1.5 (beta1) in CI. Removes v1.3 to keep to just 3 released versions (keeping v1.2 as the earliest supported release) + nightly.
2. ~(Attempts to)~ have only the latest release upload coverage results.