### PR TITLE
Rename interface functions

### DIFF
--- a/docs/src/man/devdocs.md
+++ b/docs/src/man/devdocs.md
@@ -23,17 +23,17 @@ implement.
 
 ### Normalization Interface
 
-| Interfaces to extend/implement          | Brief description                                                                               |
-|:--------------------------------------- |:----------------------------------------------------------------------------------------------- |
-| [`Legendre.AbstractLegendreNorm`](@ref) | Supertype of normalization trait types                                                          |
-| [`Legendre.Plm_00()`](@ref)             | Value of ``N_0^0 P_0^0(x)`` for the given normalization                                         |
-| [`Legendre.Plm_μ()`](@ref)              | Coefficient ``μ_ℓ`` for the 1-term r.r. boosting ``ℓ-1 → ℓ`` and ``m-1 → m`` where ``m = \ell`` |
-| [`Legendre.Plm_ν()`](@ref)              | Coefficient ``ν_ℓ`` for the 1-term r.r. boosting ``ℓ-1 → ℓ``                                    |
-| [`Legendre.Plm_α()`](@ref)              | Coefficient ``α_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ-1,m)`` term                          |
-| [`Legendre.Plm_β()`](@ref)              | Coefficient ``β_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ-2,m)`` term                        |
+| Interfaces to extend/implement          | Brief description                                                                            |
+|:--------------------------------------- |:-------------------------------------------------------------------------------------------- |
+| [`Legendre.AbstractLegendreNorm`](@ref) | Supertype of normalization trait types                                                       |
+| [`Legendre.initcond()`](@ref)           | Value of ``N_0^0 P_0^0(x)`` for the given normalization                                      |
+| [`Legendre.coeff_μ()`](@ref)            | Coefficient ``μ_ℓ`` for the 1-term r.r. boosting ``ℓ-1 → ℓ`` and ``m-1 → m`` where ``m = ℓ`` |
+| [`Legendre.coeff_ν()`](@ref)            | Coefficient ``ν_ℓ`` for the 1-term r.r. boosting ``ℓ-1 → ℓ``                                 |
+| [`Legendre.coeff_α()`](@ref)            | Coefficient ``α_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ-1,m)`` term                     |
+| [`Legendre.coeff_β()`](@ref)            | Coefficient ``β_ℓ^m`` for the 2-term r.r. acting on the ``(ℓ-2,m)`` term                     |
 
-| Optional interfaces                 | Brief description                      |
-|:----------------------------------- |:-------------------------------------- |
+| Optional interfaces                   | Brief description                      |
+|:------------------------------------- |:-------------------------------------- |
 | [`Legendre.boundscheck_hook()`](@ref) | Hook to participate in bounds checking |
 
 
@@ -140,42 +140,42 @@ Begin by importing the types and methods which will need to be extended:
 ```jldoctest λNorm
 julia> using Legendre
 
-julia> import Legendre: AbstractLegendreNorm, Plm_00, Plm_μ, Plm_ν, Plm_α, Plm_β
+julia> import Legendre: AbstractLegendreNorm, initcond, coeff_μ, coeff_ν, coeff_α, coeff_β
 ```
 We'll call our new normalization `λNorm`, which must be a subclass of
 `AbstractLegendreNorm`.
 ```jldoctest λNorm
 julia> struct λNorm <: AbstractLegendreNorm end
 ```
-The initial condition is specified by providing a method of `Plm_00` which takes our
+The initial condition is specified by providing a method of `initcond` which takes our
 normalization trait type as the first argument.
 (The second argument can be useful if some extra type information is required to set
 up a type-stable algorithm, which we'll ignore here for the sake of simplicity.)
 ```jldoctest λNorm
-julia> Plm_00(::λNorm, T::Type) = sqrt(1 / 4π)
-Plm_00 (generic function with 4 methods)
+julia> initcond(::λNorm, T::Type) = sqrt(1 / 4π)
+initcond (generic function with 4 methods)
 ```
 Finally, we provide methods which encode the cofficients as well:
 ```jldoctest λNorm
-julia> function Plm_α(::λNorm, T::Type, l::Integer, m::Integer)
+julia> function coeff_α(::λNorm, T::Type, l::Integer, m::Integer)
            fac1 = (2l + 1) / ((2l - 3) * (l^2 - m^2))
            fac2 = 4*(l-1)^2 - 1
            return sqrt(fac1 * fac2)
        end
-Plm_α (generic function with 4 methods)
+coeff_α (generic function with 4 methods)
 
-julia> function Plm_β(::λNorm, T::Type, l::Integer, m::Integer)
+julia> function coeff_β(::λNorm, T::Type, l::Integer, m::Integer)
            fac1 = (2l + 1) / ((2l - 3) * (l^2 - m^2))
            fac2 = (l-1)^2 - m^2
            return sqrt(fac1 * fac2)
        end
-Plm_β (generic function with 4 methods)
+coeff_β (generic function with 4 methods)
 
-julia> Plm_μ(::λNorm, T::Type, l::Integer) = sqrt(1 + 1 / 2l)
-Plm_μ (generic function with 4 methods)
+julia> coeff_μ(::λNorm, T::Type, l::Integer) = sqrt(1 + 1 / 2l)
+coeff_μ (generic function with 4 methods)
 
-julia> Plm_ν(::λNorm, T::Type, l::Integer) = sqrt(1 + 2l)
-Plm_ν (generic function with 4 methods)
+julia> coeff_ν(::λNorm, T::Type, l::Integer) = sqrt(1 + 2l)
+coeff_ν (generic function with 4 methods)
 ```
 
 With just those 5 methods provided, the full Legendre framework is available,

--- a/src/calculation.jl
+++ b/src/calculation.jl
@@ -115,7 +115,7 @@ _fma(x, y, z) = Base.fma(x, y, z)
         y¹[ii] = sqrt(y²[ii])
     end
 
-    fill!(pm, Plm_00(norm, T))
+    fill!(pm, initcond(norm, T))
     for m in 0:mmax
         @simd for ii in I
             if N == 2
@@ -131,7 +131,7 @@ _fma(x, y, z) = Base.fma(x, y, z)
         if N == 2 || m == mmax
             # 1-term recurrence relation taking (l-1,l-1) -> (l,l-1) where l == m == m
             l = m + 1
-            ν = Plm_ν(norm, real(T), l)
+            ν = coeff_ν(norm, real(T), l)
             @simd for ii in I
                 plm1[ii] = pm[ii]
                 pl[ii]   = ν * z[ii] * plm1[ii]
@@ -149,8 +149,8 @@ _fma(x, y, z) = Base.fma(x, y, z)
             for l in m+2:lmax
                 plm2, plm1, pl = plm1, pl, plm2
                 # 2-term recurrence relation taking (l-1,m) -> (l, m)
-                α = Plm_α(norm, real(T), l, m)
-                β = Plm_β(norm, real(T), l, m)
+                α = coeff_α(norm, real(T), l, m)
+                β = coeff_β(norm, real(T), l, m)
                 @simd for ii in I
                     pl[ii] = α * z[ii] * plm1[ii] - β * plm2[ii]
                     if N == 2
@@ -169,13 +169,13 @@ _fma(x, y, z) = Base.fma(x, y, z)
         if iseven(m)
             pmm2, pm = pm, pmm2
             # Takes even m-2 to odd m-1 for following iteration where m will be odd
-            μ₁ = Plm_μ(norm, real(T), m+1)
+            μ₁ = coeff_μ(norm, real(T), m+1)
             @simd for ii in I
                 pm[ii] = -μ₁ * y¹[ii] * pmm2[ii]
             end
         else
             # Takes even m-2 to even m for following iteration where m will be even again
-            μ₂ = Plm_μ(norm, real(T), m+1)
+            μ₂ = coeff_μ(norm, real(T), m+1)
             @simd for ii in I
                 pm[ii] = μ₁ * μ₂ * y²[ii] * pmm2[ii]
             end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -15,15 +15,15 @@ Base.broadcastable(x::AbstractLegendreNorm) = Ref(x)
 ## interface.
 
 """
-    Plm_00(::N, ::Type{T}) where {N<:AbstractLegendreNorm, T}
+    initcond(::N, ::Type{T}) where {N<:AbstractLegendreNorm, T}
 
 Returns the initial condition ``P_0^0(x)`` for the associated Legendre recursions based
 on the normalization choice `N` for numeric type `T`.
 """
-function Plm_00 end
+function initcond end
 
 """
-    Plm_μ(norm::N, ::Type{T}, l::Integer) where {N<:AbstractLegendreNorm, T}
+    coeff_μ(norm::N, ::Type{T}, l::Integer) where {N<:AbstractLegendreNorm, T}
 
 Returns the coefficient ``μ_ℓ`` for the single-term recursion relation
 ```math
@@ -31,10 +31,10 @@ Returns the coefficient ``μ_ℓ`` for the single-term recursion relation
 ```
 where ``μ_ℓ`` is appropriate for the choice of normalization `N`.
 """
-function Plm_μ end
+function coeff_μ end
 
 """
-    Plm_ν(norm::N, ::Type{T}, l::Integer) where {N<:AbstractLegendreNorm, T}
+    coeff_ν(norm::N, ::Type{T}, l::Integer) where {N<:AbstractLegendreNorm, T}
 
 Returns the coefficient ``ν_ℓ`` for the single-term recursion relation
 ```math
@@ -42,10 +42,10 @@ Returns the coefficient ``ν_ℓ`` for the single-term recursion relation
 ```
 where ``ν_ℓ`` is appropriate for the choice of normalization `N`.
 """
-function Plm_ν end
+function coeff_ν end
 
 """
-    Plm_α(norm::N, ::Type{T}, l::Integer, m::Integer) where {N<:AbstractLegendreNorm, T}
+    coeff_α(norm::N, ::Type{T}, l::Integer, m::Integer) where {N<:AbstractLegendreNorm, T}
 
 Returns the coefficient ``α_ℓ^m`` for the two-term recursion relation
 ```math
@@ -53,10 +53,10 @@ Returns the coefficient ``α_ℓ^m`` for the two-term recursion relation
 ```
 where ``α_ℓ^m`` is appropriate for the choice of normalization `N`.
 """
-function Plm_α end
+function coeff_α end
 
 """
-    Plm_β(norm::N, ::Type{T}, l::Integer, m::Integer) where {N<:AbstractLegendreNorm, T}
+    coeff_β(norm::N, ::Type{T}, l::Integer, m::Integer) where {N<:AbstractLegendreNorm, T}
 
 Returns the coefficient ``β_ℓ^m`` for the two-term recursion relation
 ```math
@@ -64,7 +64,7 @@ Returns the coefficient ``β_ℓ^m`` for the two-term recursion relation
 ```
 where ``β_ℓ^m`` is appropriate for the choice of normalization `N`.
 """
-function Plm_β end
+function coeff_β end
 
 """
     boundscheck_hook(norm::AbstractLegendreNorm, lmax, mmax)

--- a/src/norm_sphere.jl
+++ b/src/norm_sphere.jl
@@ -9,7 +9,7 @@ polynomials.
 struct LegendreSphereNorm <: AbstractLegendreNorm end
 
 @inline function
-Plm_00(::LegendreSphereNorm, ::Type{T}) where T
+initcond(::LegendreSphereNorm, ::Type{T}) where T
     # comparing this against
     #   convert(T, inv(sqrt(4*convert(BigFloat, π))))
     # shows that this is exact within Float64 precision
@@ -17,7 +17,7 @@ Plm_00(::LegendreSphereNorm, ::Type{T}) where T
 end
 
 @inline function
-Plm_μ(::LegendreSphereNorm, ::Type{T}, l::Integer) where T
+coeff_μ(::LegendreSphereNorm, ::Type{T}, l::Integer) where T
     # The direct derivation of the normalization constant gives
     #     return sqrt(one(T) + inv(convert(T, 2l)))
     # but when comparing results for T ∈ (Float64,BigFloat), the Float64 results differ by
@@ -46,16 +46,16 @@ Plm_μ(::LegendreSphereNorm, ::Type{T}, l::Integer) where T
 end
 
 @inline function
-Plm_ν(::LegendreSphereNorm, ::Type{T}, l::Integer) where T
+coeff_ν(::LegendreSphereNorm, ::Type{T}, l::Integer) where T
     return @fastmath(sqrt)(convert(T, 2l + 1))
 end
 
 @inline function
-Plm_α(::LegendreSphereNorm, ::Type{T}, l::Integer, m::Integer) where T
+coeff_α(::LegendreSphereNorm, ::Type{T}, l::Integer, m::Integer) where T
     lT = convert(T, l)
     mT = convert(T, m)
     # Write factors in two pieces to make compiler's job easier. In the case where
-    # both Plm_α and Plm_β are called and inlined, the next line from both functions
+    # both coeff_α and coeff_β are called and inlined, the next line from both functions
     # should be merged and shared.
     fac1 = (2lT + 1) / ((2lT - 3) * (lT^2 - mT^2))
     fac2 = 4*(lT - 1)^2 - 1
@@ -63,11 +63,11 @@ Plm_α(::LegendreSphereNorm, ::Type{T}, l::Integer, m::Integer) where T
 end
 
 @inline function
-Plm_β(::LegendreSphereNorm, ::Type{T}, l::Integer, m::Integer) where T
+coeff_β(::LegendreSphereNorm, ::Type{T}, l::Integer, m::Integer) where T
     lT = convert(T, l)
     mT = convert(T, m)
     # Write factors in two pieces to make compiler's job easier. In the case where
-    # both Plm_α and Plm_β are called and inlined, the next line from both functions
+    # both coeff_α and coeff_β are called and inlined, the next line from both functions
     # should be merged and shared.
     fac1 = (2lT + 1) / ((2lT - 3) * (lT^2 - mT^2))
     fac2 = (lT - 1)^2 - mT^2

--- a/src/norm_table.jl
+++ b/src/norm_table.jl
@@ -32,13 +32,13 @@ struct LegendreNormCoeff{N<:AbstractLegendreNorm,T<:Real} <: AbstractLegendreNor
         β = zeros(T, lmax+1, mmax+1)
 
         @inbounds for m in 0:mmax
-            μ[m+1] = m == 0 ? zero(T) : Plm_μ(N(), T, m)
+            μ[m+1] = m == 0 ? zero(T) : coeff_μ(N(), T, m)
             # N.B.: Need access to mmax+1 but will never use m==0 term, so offset storage
-            ν[m+1] = Plm_ν(N(), T, m+1)
+            ν[m+1] = coeff_ν(N(), T, m+1)
 
             for l in (m+1):lmax
-                α[l+1,m+1] = Plm_α(N(), T, l, m)
-                β[l+1,m+1] = Plm_β(N(), T, l, m)
+                α[l+1,m+1] = coeff_α(N(), T, l, m)
+                β[l+1,m+1] = coeff_β(N(), T, l, m)
             end
         end
 
@@ -78,28 +78,28 @@ end
 # Implements the legendre interface for the normalization
 
 @inline function
-Plm_00(::LegendreNormCoeff{N}, ::Type{T}) where {N<:AbstractLegendreNorm, T}
-    return Plm_00(N(), T)
+initcond(::LegendreNormCoeff{N}, ::Type{T}) where {N<:AbstractLegendreNorm, T}
+    return initcond(N(), T)
 end
 
 @propagate_inbounds function
-Plm_μ(norm::LegendreNormCoeff, ::Type{T}, l::Integer) where T
+coeff_μ(norm::LegendreNormCoeff, ::Type{T}, l::Integer) where T
     return norm.μ[l+1]
 end
 
 @propagate_inbounds function
-Plm_ν(norm::LegendreNormCoeff, ::Type{T}, l::Integer) where T
+coeff_ν(norm::LegendreNormCoeff, ::Type{T}, l::Integer) where T
     # N.B.: Storage is offset by 1 compared to other arrays. See constructor.
     return norm.ν[l]
 end
 
 @propagate_inbounds function
-Plm_α(norm::LegendreNormCoeff, ::Type{T}, l::Integer, m::Integer) where T
+coeff_α(norm::LegendreNormCoeff, ::Type{T}, l::Integer, m::Integer) where T
     return norm.α[l+1,m+1]
 end
 
 @propagate_inbounds function
-Plm_β(norm::LegendreNormCoeff, ::Type{T}, l::Integer, m::Integer) where T
+coeff_β(norm::LegendreNormCoeff, ::Type{T}, l::Integer, m::Integer) where T
     return norm.β[l+1,m+1]
 end
 

--- a/src/norm_unit.jl
+++ b/src/norm_unit.jl
@@ -8,26 +8,26 @@ Trait type denoting the unit normalization of the associated Legendre polynomial
 struct LegendreUnitNorm <: AbstractLegendreNorm end
 
 @inline function
-Plm_00(::LegendreUnitNorm, ::Type{T}) where T
+initcond(::LegendreUnitNorm, ::Type{T}) where T
     return one(T)
 end
 
 @inline function
-Plm_μ(::LegendreUnitNorm, ::Type{T}, l::Integer) where T
+coeff_μ(::LegendreUnitNorm, ::Type{T}, l::Integer) where T
     return convert(T, 2l - 1)
 end
 
 @inline function
-Plm_ν(::LegendreUnitNorm, ::Type{T}, l::Integer) where T
+coeff_ν(::LegendreUnitNorm, ::Type{T}, l::Integer) where T
     return convert(T, 2l - 1)
 end
 
 @inline function
-Plm_α(::LegendreUnitNorm, ::Type{T}, l::Integer, m::Integer) where T
+coeff_α(::LegendreUnitNorm, ::Type{T}, l::Integer, m::Integer) where T
     return convert(T, 2l - 1) * inv(convert(T, l - m))
 end
 
 @inline function
-Plm_β(::LegendreUnitNorm, ::Type{T}, l::Integer, m::Integer) where T
+coeff_β(::LegendreUnitNorm, ::Type{T}, l::Integer, m::Integer) where T
     return convert(T, l + m - 1) * inv(convert(T, l - m))
 end

--- a/test/analytic.jl
+++ b/test/analytic.jl
@@ -133,8 +133,8 @@ end
     #   Also test ν, and both already equivalent for unit norm.
     @testset "coeffs μ, ν ($norm)" for norm in (LegendreSphereNorm(), LegendreUnitNorm())
         lrng = 1:30_000
-        μ(T, l) = Legendre.Plm_μ(norm, T, l)
-        ν(T, l) = Legendre.Plm_ν(norm, T, l)
+        μ(T, l) = Legendre.coeff_μ(norm, T, l)
+        ν(T, l) = Legendre.coeff_ν(norm, T, l)
         @test μ.(Float64, lrng) == Float64.(μ.(BigFloat, lrng))
         @test ν.(Float64, lrng) == Float64.(ν.(BigFloat, lrng))
     end

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -15,13 +15,13 @@ module TestSuite
         @testset "Legendre Interface" begin
             @test norm isa AbstractLegendreNorm
             # Initial condition
-            @test isfinite(Legendre.Plm_00(norm, Float64))
+            @test isfinite(Legendre.initcond(norm, Float64))
             # 1-term recurrence coefficients
-            @test isfinite(Legendre.Plm_μ(norm, Float64, 1))
-            @test isfinite(Legendre.Plm_ν(norm, Float64, 1))
+            @test isfinite(Legendre.coeff_μ(norm, Float64, 1))
+            @test isfinite(Legendre.coeff_ν(norm, Float64, 1))
             # 2-term recurrence coefficients
-            @test isfinite(Legendre.Plm_α(norm, Float64, 1, 0))
-            @test isfinite(Legendre.Plm_β(norm, Float64, 1, 0))
+            @test isfinite(Legendre.coeff_α(norm, Float64, 1, 0))
+            @test isfinite(Legendre.coeff_β(norm, Float64, 1, 0))
 
             # Check that the boundscheck_hook() returns `nothing`
             @test @inferred(Legendre.boundscheck_hook(norm, 0, 0)) === nothing


### PR DESCRIPTION
I went with renaming to `Legendre.coeff_?` instead of the redundant `Legendre.legendre_?` as suggested in the issue, and `Plm_00` is being renamed to `initcond`.

Fixes #7