### PR TITLE
Fix repo path in generated docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,11 +1,22 @@
-.PHONY: build
+.PHONY: build test
 
+DOCARGS :=
 JULIA ?= julia
 mkfile_path := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+export HASTEST
 
 build:
 	cd $(realpath $(mkfile_path)..) && \
 	$(JULIA) --startup-file=no --project=docs/ \
-		-e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));' && \
+		-e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()' && \
 	$(JULIA) --startup-file=no --project=docs/ \
-		docs/make.jl
+		docs/make.jl ${DOCARGS}
+
+test: DOCARGS+=" --test"
+test: build
+	@true
+
+fix: DOCARGS+=" --fix"
+fix: build
+	@true

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,7 +28,7 @@ makedocs(
             "Private" => "lib/private.md"
         ]
     ],
-    repo = "https://github.com/jmert/Legendre.jl.git/blob/{commit}{path}#L{line}",
+    repo = "https://github.com/jmert/Legendre.jl/blob/{commit}{path}#L{line}",
 )
 
 deploydocs(


### PR DESCRIPTION
The generated docs have source links, but those are all broken at the moment. Fix that.

Also includes a change to `docs/Makefile` which makes running various configurations easier.