### PR TITLE
Add new 4π sphere (geodesy) normalization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Legendre"
 uuid = "7642852e-7f09-11e9-134e-0940411082b6"
 authors = ["Justin Willmert <justin@willmert.me>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [compat]
 julia = "1.2"

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -16,6 +16,7 @@ Nlm
 ```@docs
 AbstractLegendreNorm
 LegendreUnitNorm
+LegendreFourPiNorm
 LegendreOrthoNorm
 LegendreSphereNorm
 LegendreNormCoeff
@@ -36,6 +37,7 @@ Plm!
 There are also aliases for pre-computed coefficients of the provided normalizations.
 ```@docs
 LegendreUnitCoeff
+LegendreFourPiCoeff
 LegendreOrthoCoeff
 LegendreSphereCoeff
 ```

--- a/docs/src/man/devdocs.md
+++ b/docs/src/man/devdocs.md
@@ -153,7 +153,7 @@ normalization trait type as the first argument.
 up a type-stable algorithm, which we'll ignore here for the sake of simplicity.)
 ```jldoctest λNorm
 julia> initcond(::λNorm, T::Type) = sqrt(1 / 4π)
-initcond (generic function with 5 methods)
+initcond (generic function with 6 methods)
 ```
 Finally, we provide methods which encode the cofficients as well:
 ```jldoctest λNorm

--- a/src/Legendre.jl
+++ b/src/Legendre.jl
@@ -9,8 +9,11 @@ export AbstractLegendreNorm
 include("interface.jl")
 
 # Specific normalizations
-export LegendreUnitNorm,  LegendreOrthoNorm,  LegendreSphereNorm,  LegendreNormCoeff,
-       LegendreUnitCoeff, LegendreOrthoCoeff, LegendreSphereCoeff
+export LegendreNormCoeff,
+       LegendreUnitNorm, LegendreUnitCoeff,
+       LegendreFourPiNorm, LegendreFourPiCoeff,
+       LegendreOrthoNorm, LegendreOrthoCoeff,
+       LegendreSphereNorm, LegendreSphereCoeff
 include("norm_unit.jl")
 include("norm_sphere.jl")
 include("norm_table.jl")

--- a/src/aliases.jl
+++ b/src/aliases.jl
@@ -7,6 +7,14 @@ normalization. Alias for `LegendreNormCoeff{LegendreUnitNorm,T}`.
 LegendreUnitCoeff{T} = LegendreNormCoeff{LegendreUnitNorm,T}
 
 """
+    LegendreFourPiCoeff{T}
+
+Table type of precomputed recursion relation coefficients for the ``4\\pi`` spherical
+harmonic normalization. Alias for `LegendreNormCoeff{LegendreFourPiNorm,T}`.
+"""
+LegendreFourPiCoeff{T} = LegendreNormCoeff{LegendreFourPiNorm,T}
+
+"""
     LegendreOrthoCoeff{T}
 
 Table type of precomputed recursion relation coefficients for the orthonormal

--- a/src/calculation.jl
+++ b/src/calculation.jl
@@ -279,7 +279,7 @@ end
 @static if VERSION < v"1.3.0-alpha"
     # Prior to julia-1.3.0, abstract types could not have methods attached to them.
     # Provide for just the defined normalization types.
-    for N in (LegendreUnitNorm,LegendreSphereNorm,LegendreOrthoNorm,LegendreNormCoeff)
+    for N in (LegendreUnitNorm,LegendreSphereNorm,LegendreOrthoNorm,LegendreFourPiNorm,LegendreNormCoeff)
         @eval begin
             @inline function (norm::$N)(l, m, x)
                 return legendre(norm, l, m, x)

--- a/test/analytic.jl
+++ b/test/analytic.jl
@@ -35,8 +35,10 @@ end
 
 # P_0^0 is constant. Verify the output is invariant for several inputs.
 @testset "Constant P_0^0 ($T)" for T in NumTypes
+    @test @inferred(legendre(LegendreFourPiNorm(), 0, 0, T(0.1))) isa T
     @test @inferred(legendre(LegendreOrthoNorm(),  0, 0, T(0.1))) isa T
     @test @inferred(legendre(LegendreSphereNorm(), 0, 0, T(0.1))) isa T
+    @test all(legendre(LegendreFourPiNorm(), 0, 0, x) == one(T)           for x in xrange(T))
     @test all(legendre(LegendreOrthoNorm(),  0, 0, x) == sqrt(T(0.5))     for x in xrange(T))
     @test all(legendre(LegendreSphereNorm(), 0, 0, x) == sqrt(inv(4T(π))) for x in xrange(T))
 end
@@ -102,7 +104,7 @@ end
     end
 end
 
-# The normal P_ℓ^m should be equal to the spherical harmonic normalized
+# The orthonormal O_ℓ^m should be equal to the spherical harmonic normalized
 # λ_ℓ^m if we manually normalize them.
 @testset "Equality of (2π)^(-1/2) O_ℓ^m and λ_ℓ^m ($T)" for T in NumTypes
     LMAX = 5
@@ -113,6 +115,20 @@ end
         legendre!(LegendreOrthoNorm(),  plm_orth, LMAX, LMAX, x)
         legendre!(LegendreSphereNorm(), plm_sphr, LMAX, LMAX, x)
         @test all(isapprox.(plm_orth./sqrt(2T(π)), plm_sphr, atol=atol))
+    end
+end
+
+# The spherical and 4π-normalized functions should be the same up to the
+# differing factor of 1/√4π
+@testset "Equality of (4π)^(-1/2) F_ℓ^m and λ_ℓ^m ($T)" for T in NumTypes
+    LMAX = 5
+    atol = max(eps(4T(π)), eps(4.0π))
+    plm_4pi  = zeros(T, LMAX+1, LMAX+1)
+    plm_sphr = zeros(T, LMAX+1, LMAX+1)
+    for x in xrange(T)
+        legendre!(LegendreFourPiNorm(), plm_4pi,  LMAX, LMAX, x)
+        legendre!(LegendreSphereNorm(), plm_sphr, LMAX, LMAX, x)
+        @test all(isapprox.(plm_4pi./sqrt(4T(π)), plm_sphr, atol=atol))
     end
 end
 

--- a/test/norms.jl
+++ b/test/norms.jl
@@ -3,6 +3,9 @@ import ..TestSuite
 @testset "Unit normalization" begin
     TestSuite.runtests(LegendreUnitNorm())
 end
+@testset "4π normalization" begin
+    TestSuite.runtests(LegendreFourPiNorm())
+end
 @testset "Orthonormal normalization" begin
     TestSuite.runtests(LegendreOrthoNorm())
 end


### PR DESCRIPTION
Defined such that the integrating square of this normalization times the complex exponential
in azimuth equals the surface area of the unit sphere. This complements the spherical
normalization `LegendreSphereNorm` which instead integrates over the sphere to unity.
    
Also adds an intermediate `AbstractLegendreSphereNorm <: AbstractLegendreNorm`
in the abstract type hierarchy to consolidate the coefficients for
all three of `LegendreFourPiNorm`, `LegendreOrthoNorm`, and
`LegendreSphereNorm`.
    
The original motivation was to see if replacing the initial condition of 1 / sqrt(4π) which
must necessarily be rounded (because π is trancendental) with an exactly-representable value
(1.0 for the 4π normalization) could lead to better numerical precision. Namely, I thought
that something like summing over many terms could show the accumulated bias, but I haven't
actually found that to be true in practice. Nonetheless, having another option for a
built-in normalizations is still useful.