### PR TITLE
Add an orthonormal normalization type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         version:
           - '1.2'     # earliest supported
-          - '1.5'     # latest release
+          - '1'       # latest release
           - 'nightly'
         os:
           - ubuntu-latest
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.5'
+          version: '1'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -16,6 +16,7 @@ Nlm
 ```@docs
 AbstractLegendreNorm
 LegendreUnitNorm
+LegendreOrthoNorm
 LegendreSphereNorm
 LegendreNormCoeff
 ```
@@ -35,6 +36,7 @@ Plm!
 There are also aliases for pre-computed coefficients of the provided normalizations.
 ```@docs
 LegendreUnitCoeff
+LegendreOrthoCoeff
 LegendreSphereCoeff
 ```
 

--- a/docs/src/man/devdocs.md
+++ b/docs/src/man/devdocs.md
@@ -153,7 +153,7 @@ normalization trait type as the first argument.
 up a type-stable algorithm, which we'll ignore here for the sake of simplicity.)
 ```jldoctest λNorm
 julia> initcond(::λNorm, T::Type) = sqrt(1 / 4π)
-initcond (generic function with 4 methods)
+initcond (generic function with 5 methods)
 ```
 Finally, we provide methods which encode the cofficients as well:
 ```jldoctest λNorm

--- a/docs/src/man/usage.md
+++ b/docs/src/man/usage.md
@@ -137,7 +137,7 @@ For a specific degree and order, the output array will have the same shape as th
 argument:
 ```jldoctest PlmUsage
 julia> λlm(2, 0, reshape(range(0, 1, length=4), 2, 2))
-2×2 Array{Float64,2}:
+2×2 Matrix{Float64}:
  -0.315392  0.105131
  -0.210261  0.630783
 ```
@@ -145,7 +145,7 @@ Then adding a range of degrees increases the dimensionality by 1, with the trail
 dimension being over ``\ell``,
 ```jldoctest PlmUsage
 julia> λlm(0:2, 0, reshape(range(0, 1, length=4), 2, 2))
-2×2×3 Array{Float64,3}:
+2×2×3 Array{Float64, 3}:
 [:, :, 1] =
  0.282095  0.282095
  0.282095  0.282095
@@ -175,7 +175,7 @@ For example, to calculate the single value ``\lambda_{700}^{200}(0.5)``, provide
 0-dimensional output array (to match the 0-dimensionality of the scalar `0.5`)
 ```jldoctest PlmUsage
 julia> λlm!(fill(NaN), 700, 2, 0.5)
-0-dimensional Array{Float64,0}:
+0-dimensional Array{Float64, 0}:
 0.24148976866924293
 ```
 and filling a vector or matrix instead calculates all degrees up to the given maximum
@@ -246,7 +246,7 @@ julia> fill!(Λ, 0);
 julia> legendre!(coeff, Λ, 2, 2, 0.5);
 
 julia> Λ[1:5, 1:5]
-5×5 Array{Float64,2}:
+5×5 Matrix{Float64}:
   0.282095    0.0       0.0       0.0  0.0
   0.244301   -0.299207  0.0       0.0  0.0
  -0.0788479  -0.334523  0.289706  0.0  0.0

--- a/src/Legendre.jl
+++ b/src/Legendre.jl
@@ -9,8 +9,8 @@ export AbstractLegendreNorm
 include("interface.jl")
 
 # Specific normalizations
-export LegendreUnitNorm,  LegendreSphereNorm,  LegendreNormCoeff,
-       LegendreUnitCoeff, LegendreSphereCoeff
+export LegendreUnitNorm,  LegendreOrthoNorm,  LegendreSphereNorm,  LegendreNormCoeff,
+       LegendreUnitCoeff, LegendreOrthoCoeff, LegendreSphereCoeff
 include("norm_unit.jl")
 include("norm_sphere.jl")
 include("norm_table.jl")

--- a/src/aliases.jl
+++ b/src/aliases.jl
@@ -7,6 +7,14 @@ normalization. Alias for `LegendreNormCoeff{LegendreUnitNorm,T}`.
 LegendreUnitCoeff{T} = LegendreNormCoeff{LegendreUnitNorm,T}
 
 """
+    LegendreOrthoCoeff{T}
+
+Table type of precomputed recursion relation coefficients for the orthonormal
+normalization. Alias for `LegendreNormCoeff{LegendreOrthoNorm,T}`.
+"""
+LegendreOrthoCoeff{T} = LegendreNormCoeff{LegendreOrthoNorm,T}
+
+"""
     LegendreSphereCoeff{T}
 
 Table type of precomputed recursion relation coefficients for the spherical

--- a/src/calculation.jl
+++ b/src/calculation.jl
@@ -279,7 +279,7 @@ end
 @static if VERSION < v"1.3.0-alpha"
     # Prior to julia-1.3.0, abstract types could not have methods attached to them.
     # Provide for just the defined normalization types.
-    for N in (LegendreUnitNorm,LegendreSphereNorm,LegendreNormCoeff)
+    for N in (LegendreUnitNorm,LegendreSphereNorm,LegendreOrthoNorm,LegendreNormCoeff)
         @eval begin
             @inline function (norm::$N)(l, m, x)
                 return legendre(norm, l, m, x)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,7 +1,7 @@
 """
     abstract type AbstractLegendreNorm end
 
-Abstract trait supertype for normalization conditions of the Associated Legendre polynomials.
+Abstract trait supertype for normalization conditions of the associated Legendre functions.
 """
 abstract type AbstractLegendreNorm end
 

--- a/src/norm_unit.jl
+++ b/src/norm_unit.jl
@@ -3,7 +3,13 @@
 """
     struct LegendreUnitNorm <: AbstractLegendreNorm end
 
-Trait type denoting the unit normalization of the associated Legendre polynomials.
+Trait type denoting the unnormalized associated Legendre functions ``P_\\ell^m(x)``
+which solve the colatitude ``\\theta`` part of Laplace's equation in spherical coordinates
+where ``x=\\cos(\\theta)``.
+The degree ``\\ell=0``, order ``m=0`` constant function is normalized to be unity:
+```math
+    P_0^0(x) = 1
+```
 """
 struct LegendreUnitNorm <: AbstractLegendreNorm end
 

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -1,25 +1,41 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "f1b523983a58802c4695851926203b36e28f09db"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "3.3.0"
+
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[BinDeps]]
-deps = ["Libdl", "Pkg", "SHA", "URIParser", "Unicode"]
-git-tree-sha1 = "46cf2c1668ad07aba5a9d331bdeea994a1f13856"
-uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
-version = "1.0.1"
-
-[[BinaryProvider]]
-deps = ["Libdl", "SHA"]
-git-tree-sha1 = "5b08ed6036d9d3f0ee6369410b830f8873d4024c"
-uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.5.8"
+[[ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "9b0375dc013ab0fc472b37cb8b18eed66b83f76b"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "0.9.43"
 
 [[CommonSubexpressions]]
-deps = ["Test"]
-git-tree-sha1 = "efdaf19ab11c7889334ca247ff4c9f7c322817b0"
+deps = ["MacroTools", "Test"]
+git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
 uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
-version = "0.2.0"
+version = "0.3.0"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "0900bc19193b8e672d9cd477e6cd92d9e7c02f99"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.29.0"
+
+[[CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 
 [[Dates]]
 deps = ["Printf"]
@@ -30,17 +46,21 @@ git-tree-sha1 = "9824894295b62a6a4ab6adf1c7bf337b3a9ca34c"
 uuid = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 version = "1.2.0"
 
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
 [[DiffResults]]
 deps = ["StaticArrays"]
-git-tree-sha1 = "da24935df8e0c6cf28de340b958f6aac88eaa0cc"
+git-tree-sha1 = "c18e98cba888c6c25d1c3b048e4b3380ca956805"
 uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
-version = "1.0.2"
+version = "1.0.3"
 
 [[DiffRules]]
 deps = ["NaNMath", "Random", "SpecialFunctions"]
-git-tree-sha1 = "eb0c34204c8410888844ada5359ac8b96292cfd1"
+git-tree-sha1 = "214c3fcac57755cfda163d91c58893a8723f93e9"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.0.1"
+version = "1.0.2"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
@@ -48,9 +68,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DocStringExtensions]]
 deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "88bb0edb352b16608036faadcc071adda068582a"
+git-tree-sha1 = "9d4f64f79012636741cf01133158a54b24924c32"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.1"
+version = "0.8.4"
 
 [[Documenter]]
 deps = ["Base64", "Dates", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
@@ -59,25 +79,47 @@ pinned = true
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 version = "0.24.0"
 
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
 [[ForwardDiff]]
-deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "NaNMath", "Random", "SpecialFunctions", "StaticArrays"]
-git-tree-sha1 = "869540e4367122fbffaace383a5bdc34d6e5e5ac"
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "NaNMath", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
+git-tree-sha1 = "e2af66012e08966366a43251e1fd421522908be6"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.10"
+version = "0.10.18"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
+[[JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.3.0"
+
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "b34d7cef7b337321e97d22242c3c2b91f476748e"
+git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.0"
+version = "0.21.1"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
 
 [[LibGit2]]
-deps = ["Printf"]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -86,42 +128,77 @@ uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 deps = ["Libdl"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
+[[LogExpFunctions]]
+deps = ["DocStringExtensions", "LinearAlgebra"]
+git-tree-sha1 = "ed26854d7c2c867d143f0e07c198fc9e8b721d10"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.2.3"
+
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "6a8a2a625ab0dea913aba95c11370589e0239ff0"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.6"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
 [[NaNMath]]
-git-tree-sha1 = "928b8ca9b2791081dc71a51c55347c27c618760f"
+git-tree-sha1 = "bfe47e760d60b82b66b61d2d44128b62e3a369fb"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-version = "0.3.3"
+version = "0.3.5"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
 [[OffsetArrays]]
-git-tree-sha1 = "930db8ef90483570107f2396b1ffc6680f08e8b7"
+deps = ["Adapt"]
+git-tree-sha1 = "47b443d2ccc8297a4c538f55f8fd828ad58599ab"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.0.4"
+version = "1.8.0"
+
+[[OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "b9b8b8ed236998f91143938a760c2112dceeb2b4"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.4+0"
 
 [[Parsers]]
-deps = ["Dates", "Test"]
-git-tree-sha1 = "f8f5d2d4b4b07342e5811d2b6428e45524e241df"
+deps = ["Dates"]
+git-tree-sha1 = "c8abc88faa3f7a3950832ac5d6e690881590d6dc"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.2"
+version = "1.1.0"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "00cfd92944ca9c760982747e9a1d0d5d86ab1e5a"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.2"
 
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
@@ -134,6 +211,10 @@ uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
@@ -142,23 +223,31 @@ deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SpecialFunctions]]
-deps = ["BinDeps", "BinaryProvider", "Libdl"]
-git-tree-sha1 = "3bdd374b6fd78faf0119b8c5d538788dbf910c6e"
+deps = ["ChainRulesCore", "LogExpFunctions", "OpenSpecFun_jll"]
+git-tree-sha1 = "9146da51b38e9705b9f5ccfadc3ab10a482cae36"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "0.8.0"
+version = "1.4.0"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "5a3bcb6233adabde68ebc97be66e95dcb787424c"
+git-tree-sha1 = "c635017268fd51ed944ec429bcc4ad010bcea900"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "0.12.1"
+version = "1.2.0"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
 [[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[TestSetExtensions]]
@@ -167,15 +256,21 @@ git-tree-sha1 = "3a2919a78b04c29a1a57b05e1618e473162b15d0"
 uuid = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
 version = "2.0.0"
 
-[[URIParser]]
-deps = ["Test", "Unicode"]
-git-tree-sha1 = "6ddf8244220dfda2f17539fa8c9de20d6c575b69"
-uuid = "30578b45-9adc-5946-b283-645ec420af67"
-version = "0.4.0"
-
 [[UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/test/analytic.jl
+++ b/test/analytic.jl
@@ -1,5 +1,7 @@
 using LinearAlgebra
 
+xrange(::Type{T}, len=11) where {T} = range(-one(T), one(T), length = len)
+
 ##################################
 # UNNORMALIZED LEGENDRE FUNCTIONS
 ##################################
@@ -7,8 +9,7 @@ using LinearAlgebra
 # P_0^0 is constant. Verify the output is invariant for several inputs.
 @testset "Constant P_0^0 ($T)" for T in NumTypes
     @test @inferred(legendre(LegendreUnitNorm(), 0, 0, T(0.1))) isa T
-    @test all(legendre(LegendreUnitNorm(), 0, 0, z) == one(T)
-              for z in range(-one(T), one(T), length=10))
+    @test all(legendre(LegendreUnitNorm(), 0, 0, x) == one(T) for x in xrange(T))
 end
 
 # Match P_ℓ^{m=0} terms for ℓ=1...9 where the analytical expressions
@@ -34,12 +35,10 @@ end
 
 # P_0^0 is constant. Verify the output is invariant for several inputs.
 @testset "Constant P_0^0 ($T)" for T in NumTypes
-    @test @inferred(legendre(LegendreOrthoNorm(), 0, 0, T(0.1))) isa T
+    @test @inferred(legendre(LegendreOrthoNorm(),  0, 0, T(0.1))) isa T
     @test @inferred(legendre(LegendreSphereNorm(), 0, 0, T(0.1))) isa T
-    @test all(legendre(LegendreOrthoNorm(), 0, 0, z) == sqrt(T(0.5))
-              for z in range(-one(T), one(T), length=10))
-    @test all(legendre(LegendreSphereNorm(), 0, 0, z) == sqrt(inv(4T(π)))
-              for z in range(-one(T), one(T), length=10))
+    @test all(legendre(LegendreOrthoNorm(),  0, 0, x) == sqrt(T(0.5))     for x in xrange(T))
+    @test all(legendre(LegendreSphereNorm(), 0, 0, x) == sqrt(inv(4T(π))) for x in xrange(T))
 end
 
 # The initialization condition
@@ -96,9 +95,8 @@ end
     lmat = tril(repeat(collect(0:LMAX), 1, LMAX+1))
     mmat = tril(repeat(collect(0:LMAX)', LMAX+1, 1))
     nlm = tril(Nlm.(T, lmat, mmat))
-    for ii in 1:10
-        x = 2*T(rand()) - 1
-        legendre!(LegendreUnitNorm(), plm_norm, LMAX, LMAX, x)
+    for x in xrange(T)
+        legendre!(LegendreUnitNorm(),   plm_norm, LMAX, LMAX, x)
         legendre!(LegendreSphereNorm(), plm_sphr, LMAX, LMAX, x)
         @test all(isapprox.(nlm.*plm_norm, plm_sphr, atol=atol))
     end
@@ -111,9 +109,8 @@ end
     atol = max(eps(T(100)), eps(100.0)) # maximum(plm_norm) is of order 10²
     plm_orth = zeros(T, LMAX+1, LMAX+1)
     plm_sphr = zeros(T, LMAX+1, LMAX+1)
-    for ii in 1:10
-        x = 2*T(rand()) - 1
-        legendre!(LegendreOrthoNorm(), plm_orth, LMAX, LMAX, x)
+    for x in xrange(T)
+        legendre!(LegendreOrthoNorm(),  plm_orth, LMAX, LMAX, x)
         legendre!(LegendreSphereNorm(), plm_sphr, LMAX, LMAX, x)
         @test all(isapprox.(plm_orth./sqrt(2T(π)), plm_sphr, atol=atol))
     end
@@ -126,7 +123,7 @@ end
 # Trivial case: real-only complex arguments should be identical to the real case
 @testset "Complex arguments, real axis ($T)" for T in NumTypes
     LMAX = 10
-    x = collect(range(-one(T), one(T), length=100))
+    x = xrange(T, 100)
     z = complex(x)
     @test Plm.(0:LMAX, 0:LMAX, x) == real.(Plm.(0:LMAX, 0:LMAX, z))
     @test λlm.(0:LMAX, 0:LMAX, x) == real.(λlm.(0:LMAX, 0:LMAX, z))

--- a/test/doctests.jl
+++ b/test/doctests.jl
@@ -1,11 +1,14 @@
 using Documenter, Logging
 
-# Disable Documeter's Info logging
-oldlvl = Logging.min_enabled_level(current_logger())
-disable_logging(Logging.Info)
-try
-    DocMeta.setdocmeta!(Legendre, :DocTestSetup, :(using Legendre); recursive=true)
-    doctest(Legendre, testset="Doc Tests")
-finally
-    disable_logging(oldlvl - 1)
+# Outputs are Julia version specific
+if VERSION >= v"1.6"
+    # Disable Documeter's Info logging
+    oldlvl = Logging.min_enabled_level(current_logger())
+    disable_logging(Logging.Info)
+    try
+        DocMeta.setdocmeta!(Legendre, :DocTestSetup, :(using Legendre); recursive=true)
+        doctest(Legendre, testset="Doc Tests")
+    finally
+        disable_logging(oldlvl - 1)
+    end
 end

--- a/test/norms.jl
+++ b/test/norms.jl
@@ -3,6 +3,9 @@ import ..TestSuite
 @testset "Unit normalization" begin
     TestSuite.runtests(LegendreUnitNorm())
 end
+@testset "Orthonormal normalization" begin
+    TestSuite.runtests(LegendreOrthoNorm())
+end
 @testset "Spherical normalization" begin
     TestSuite.runtests(LegendreSphereNorm())
 end


### PR DESCRIPTION
This adds another provided normalization which produces the associated Legendre functions which are normalized such that the squared integral is equal to 1. The normalization differs from the already-provided spherical harmonic normalization in the initial condition.
Includes minor updates to documentation and CI as well to update for Julia 1.6.